### PR TITLE
removed test time option, since it is overwritten with current time b…

### DIFF
--- a/bin/dmagic
+++ b/bin/dmagic
@@ -72,9 +72,6 @@ def init(args):
 
 
 def show(args):
-    # set the experiment date 
-    # testing date
-    # now = datetime.datetime(2016, 2, 19, 10, 10, 30)
     now = datetime.datetime.today()
     log.info("Today's date: %s" % now)
     scheduling.print_current_experiment_info(args)


### PR DESCRIPTION
…y scheduling.print_current_experiment_info()