### PR TITLE
'Update README and docs to reflect current codebase state

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,37 @@
 Project Home Page: http://dmagic.readthedocs.org/
+
+dmagic (Data Magic) is a tool developed at Argonne National Laboratory for managing
+experiment metadata at APS (Advanced Photon Source) beamlines. It bridges the APS
+scheduling system (which tracks who is running experiments and when) with the EPICS
+control system used to operate beamline equipment.
+
+Key Commands
+------------
+
+- dmagic show  : Queries the APS scheduling REST API to display the currently active
+                 experiment's information: PI name, affiliation, email, badge number,
+                 proposal ID/title, and start/end times.
+
+- dmagic tag   : Fetches the same scheduling data and writes it into EPICS Process
+                 Variables (PVs) on the beamline's TomoScan IOC. This populates fields
+                 like UserName, UserEmail, ProposalNumber, ProposalTitle, etc. in real-time.
+
+- dmagic init  : Creates a configuration file.
+
+How It Works
+------------
+
+1. Authenticates against the APS scheduling REST API using stored credentials.
+2. Determines the current APS run (e.g., "2024-1") based on the current date.
+3. Finds the proposal scheduled for the current beamline at the current time.
+4. Extracts PI and experiment metadata from the proposal.
+5. Optionally writes that metadata to EPICS PVs so downstream data acquisition software
+   (like TomoScan) can tag collected data with the correct experiment/user info.
+
+Use Case
+--------
+
+Primarily used at tomography beamlines (e.g., 2-BM, 7-BM, 32-ID) so that when a new
+user group arrives to run their approved experiment, the beamline control system is
+automatically updated with their identity and proposal information, ensuring data files
+are properly attributed without manual entry.

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -2,17 +2,18 @@
 About
 =====
 
-`DMagic <https://github.com/xray-imaging/DMagic>`_ aims to provide easy command-line
-interface to the `APS scheduling system <https://schedule.aps.anl.gov/>`_
+`DMagic <https://github.com/xray-imaging/DMagic>`_ provides a command-line interface to the
+`APS scheduling system <https://schedule.aps.anl.gov/>`_.
 
-Basic functionalities include the ability, for the current experiment, to retrieve the users' 
-email addresses from the APS scheduling as well as experiment information. This infomation can 
-be printed ("show" option) or used to update EPICS PVs ("tag" option)
+It bridges the APS scheduling system (which tracks who is running experiments and when) with
+the `EPICS <https://epics-controls.org/>`_ control system used to operate beamline equipment.
 
+For the current experiment, DMagic can retrieve PI and user information (name, affiliation,
+email, badge number) as well as proposal metadata (GUP ID, title, start/end times). This
+information can be printed to the terminal (``show`` command) or written directly into EPICS
+Process Variables on the beamline IOC (``tag`` command), ensuring that data files are
+automatically attributed to the correct user group without manual entry.
 
-`DMagic <https://github.com/xray-imaging/DMagic>`_ supports `Globus <https://github.com/xray-imaging/Globus>`_
-a tool to automatically create Globus shared folders with users.
-
-`DMagic <https://github.com/xray-imaging/DMagic>`_  and `Globus <https://github.com/xray-imaging/Globus>`_ are designed 
-to help managing the massive amount of data generated at the `Advanced Photon Source <http://www.aps.anl.gov>`_ by providing 
-an automatic way to tag, share, notify and distribute data to users.
+DMagic is primarily used at tomography beamlines (e.g. 2-BM, 7-BM, 32-ID) in conjunction
+with `tomoScan <https://tomoscan.readthedocs.io/>`_ to populate user information PVs at the
+start of each user run.

--- a/docs/source/api/dmagic.scheduling.rst
+++ b/docs/source/api/dmagic.scheduling.rst
@@ -18,3 +18,4 @@
       get_current_proposal_id
       get_current_proposal_title
       get_current_users
+      get_proposal_starting_date

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -29,7 +29,7 @@ Install DMagic::
     (dm) $ cd DMagic
     (dm) $ pip install .
 
-Install all packages listed in the ``env/requirements.txt`` file::
+Install all packages listed in the ``envs/requirements.txt`` file::
 
     (dm) $ conda install pytz
     (dm) $ conda install requests
@@ -76,7 +76,7 @@ IOC prefix where the PVs are stored at runtime using the --beamline and --tomosc
       --set SET             Number of +/- number days for the current date. Used for setting user info for past/future user groups (default: 0)
       --tomoscan-prefix TOMOSCAN_PREFIX
                             The tomoscan prefix, i.e.'7bmb1:' or '2bma:TomoScan:' (default: 7bmb1:)
-      --url URL             URL address of the scheduling system REST API' (default: https://mis7.aps.anl.gov:7004)
+      --url URL             URL address of the scheduling system REST API' (default: https://beam-api.aps.anl.gov)
       --config FILE         File name of configuration (default: /Users/decarlo/dmagic.conf)
       --verbose             Verbose output (default: True)
 
@@ -116,13 +116,12 @@ Update
 Dependencies
 ============
 
-Install the following package::
+Install the following packages::
 
     $ pip install pyepics
     $ pip install pytz
-    $ conda install decorator
-    $ conda install numpy
+    $ pip install requests
 
-.. warning:: If required edit your .cshrc or .bashrc to set PYEPICS_LIBCA: Example: setenv PYEPICS_LIBCA /APSshare/epics/extensions-base/3.14.12.2-ext1/lib/linux-x86_64/libca.so
+.. warning:: If required, edit your .cshrc or .bashrc to set PYEPICS_LIBCA. Example: setenv PYEPICS_LIBCA /APSshare/epics/extensions-base/3.14.12.2-ext1/lib/linux-x86_64/libca.so
 
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -2,7 +2,7 @@
 Usage
 =====
 
-DMagic retrieves user and experiment information from the APS scheduling system. To initlialize DMagic status::
+DMagic retrieves user and experiment information from the APS scheduling system. To initialize DMagic status::
 
     (dm) $ dmagic init
     2024-03-29 20:18:31,165 - General
@@ -11,12 +11,12 @@ DMagic retrieves user and experiment information from the APS scheduling system.
 
 this creates the DMagic config file: ~/dmagic.conf with default values.
 
-To configure for your beamline and show the list of users that run 1,500 days ago from today:
+To configure for your beamline and show the list of users that ran 1,500 days ago from today:
 
 ::
 
     (dm) $ dmagic show --beamline 2-BM-A,B --tomoscan-prefix  2bmb:TomoScan: --set -1500
-    2024-03-29 20:20:57,239 - Today's date: 2020-02-19 20:20:57.239632
+    2024-03-29 20:20:57,239 - Today's date: 2020-02-19 20:20:57.239632+00:00
     2024-03-29 20:20:57,968 -   Run: 2020-1
     2024-03-29 20:20:57,968 -   PI Name: Weinong Chen
     2024-03-29 20:20:57,969 -   PI affiliation: Purdue University
@@ -24,17 +24,17 @@ To configure for your beamline and show the list of users that run 1,500 days ag
     2024-03-29 20:20:57,969 -   PI badge: 226531
     2024-03-29 20:20:57,969 -   Proposal GUP: 66310
     2024-03-29 20:20:57,969 -   Proposal Title: In-situ visualization of pull-out behavior of z-pin reinforcement in sandwich panels using X-ray computed tomography
-    2024-03-29 20:20:57,969 -   Start time: s
-    2024-03-29 20:20:57,969 -   End Time: s
-    2024-03-29 20:20:57,969 -   User email address: 
-    2024-03-29 20:20:57,969 -       jonathan.drk@gmail.com
-    2024-03-29 20:20:57,969 -       cdkirk@sandia.gov
-    2024-03-29 20:20:57,969 -       gzherui@purdue.edu
-    2024-03-29 20:20:57,969 -       scpaulson42@gmail.com
-    2024-03-29 20:20:57,969 -       nkedir@purdue.edu
-    2024-03-29 20:20:57,969 -       wchen@purdue.edu
-    2024-03-29 20:20:57,969 -       aleenig@purdue.edu
-    2024-03-29 20:20:57,969 -       wchen@purdue.edu
+    2024-03-29 20:20:57,969 -   Start date: 2020_02_17
+    2024-03-29 20:20:57,969 -   Start time: 2020-02-17 08:00:00-06:00
+    2024-03-29 20:20:57,969 -   End Time: 2020-02-19 08:00:00-06:00
+    2024-03-29 20:20:57,969 -   User email address:
+    2024-03-29 20:20:57,969 -        jonathan.drk@gmail.com
+    2024-03-29 20:20:57,969 -        cdkirk@sandia.gov
+    2024-03-29 20:20:57,969 -        gzherui@purdue.edu
+    2024-03-29 20:20:57,969 -        scpaulson42@gmail.com
+    2024-03-29 20:20:57,969 -        nkedir@purdue.edu
+    2024-03-29 20:20:57,969 -        wchen@purdue.edu
+    2024-03-29 20:20:57,969 -        aleenig@purdue.edu
     2024-03-29 20:20:57,970 - General
     2024-03-29 20:20:57,970 -   config           /Users/decarlo/dmagic.conf
     2024-03-29 20:20:57,970 -   verbose          True
@@ -42,10 +42,10 @@ To configure for your beamline and show the list of users that run 1,500 days ag
     2024-03-29 20:20:57,970 -   beamline         2-BM-A,B
     2024-03-29 20:20:57,970 -   set              -1500.0
     2024-03-29 20:20:57,970 -   tomoscan_prefix  2bmb:TomoScan:
-    2024-03-29 20:20:57,970 -   url              https://mis7.aps.anl.gov:7004
+    2024-03-29 20:20:57,970 -   url              https://beam-api.aps.anl.gov
 
 .. note::
-    You only need to pass ``--beamline 2-BM-A,B`` and  ``--tomoscan-prefix 2bmb:TomoScan:`` once, 
+    You only need to pass ``--beamline 2-BM-A,B`` and  ``--tomoscan-prefix 2bmb:TomoScan:`` once,
     then you can only run ``dmagic show``
 
 
@@ -56,25 +56,25 @@ To update the EPICS PVs with data retrieved from the APS scheduling system run:
     (dm) $ dmagic tag
     2024-03-29 20:29:02,028 - Today's date: 2024-03-29 20:29:02.028035
     2024-03-29 20:29:02,700 - User/Experiment PV update
-    2024-03-29 20:29:04,701 - Updated EPICS PV with: Weinong
-    2024-03-29 20:29:06,701 - Updated EPICS PV with: Chen
-    2024-03-29 20:29:08,702 - Updated EPICS PV with: Purdue University
-    2024-03-29 20:29:10,702 - Updated EPICS PV with: wchen@purdue.edu
-    2024-03-29 20:29:12,702 - Updated EPICS PV with: 226531
-    2024-03-29 20:29:14,704 - Updated EPICS PV with: 2024-03-29T20:29:02.028035-05:00
-    2024-03-29 20:29:16,704 - Updated EPICS PV with: 66310
-    2024-03-29 20:29:18,704 - Updated EPICS PV with: In-situ visualization of pull-out behavior of z-pin reinforcement in sandwich panels using X-ray computed tomography
-    2024-03-29 20:29:20,707 - Updated EPICS PV with: 2020-02
-    2024-03-29 20:29:20,707 - General
-    2024-03-29 20:29:20,707 -   config           /Users/decarlo/dmagic.conf
-    2024-03-29 20:29:20,707 -   verbose          True
-    2024-03-29 20:29:20,707 - Settings
-    2024-03-29 20:29:20,707 -   beamline         2-BM-A,B
-    2024-03-29 20:29:20,707 -   set              -1500.0
-    2024-03-29 20:29:20,707 -   tomoscan_prefix  2bmb:TomoScan:
-    2024-03-29 20:29:20,707 -   url              https://mis7.aps.anl.gov:7004
+    2024-03-29 20:29:02,701 - Updating pi_name EPICS PV with: Weinong
+    2024-03-29 20:29:02,702 - Updating pi_last_name EPICS PV with: Chen
+    2024-03-29 20:29:02,703 - Updating pi_affiliation EPICS PV with: Purdue University
+    2024-03-29 20:29:02,704 - Updating pi_email EPICS PV with: wchen@purdue.edu
+    2024-03-29 20:29:02,705 - Updating pi_badge EPICS PV with: 226531
+    2024-03-29 20:29:02,706 - Updating user_info_update_time EPICS PV with: 2024-03-29T20:29:02.028035-05:00
+    2024-03-29 20:29:02,707 - Updating proposal_number EPICS PV with: 66310
+    2024-03-29 20:29:02,708 - Updating proposal_title EPICS PV with: In-situ visualization of pull-out behavior of z-pin reinforcement in sandwich panels using X-ray computed tomography
+    2024-03-29 20:29:02,709 - Updating experiment_date EPICS PV with: 2020-02
+    2024-03-29 20:29:02,710 - General
+    2024-03-29 20:29:02,710 -   config           /Users/decarlo/dmagic.conf
+    2024-03-29 20:29:02,710 -   verbose          True
+    2024-03-29 20:29:02,710 - Settings
+    2024-03-29 20:29:02,710 -   beamline         2-BM-A,B
+    2024-03-29 20:29:02,710 -   set              -1500.0
+    2024-03-29 20:29:02,710 -   tomoscan_prefix  2bmb:TomoScan:
+    2024-03-29 20:29:02,710 -   url              https://beam-api.aps.anl.gov
 
-The information associated with the current user/experiment will be updated in the medm screen: 
+The information associated with the current user/experiment will be updated in the medm screen:
 
 .. image:: img/medm_screen.png
   :width: 400
@@ -90,7 +90,7 @@ For help::
       --config FILE  File name of configuration
 
     Commands:
-      
+
         init         Create configuration file
         show         Show user and experiment info from the APS schedule
         tag          Update user info EPICS PVs with info from the APS schedule
@@ -98,18 +98,6 @@ For help::
 To access all options::
 
     (dm) $ dmagic show -h
-    usage: dmagic [-h] [--config FILE]  ...
-
-    optional arguments:
-      -h, --help     show this help message and exit
-      --config FILE  File name of configuration
-
-    Commands:
-      
-        init         Create configuration file
-        show         Show user and experiment info from the APS schedule
-        tag          Update user info EPICS PVs with info from the APS schedule
-    (dm) decarlo@marmot DMagic-decarlof % dmagic show -h
     usage: dmagic show [-h] [--beamline BEAMLINE] [--set SET] [--tomoscan-prefix TOMOSCAN_PREFIX] [--url URL] [--config FILE] [--verbose]
 
     optional arguments:
@@ -118,7 +106,7 @@ To access all options::
       --set SET             Number of +/- number days for the current date. Used for setting user info for past/future user groups (default: 0)
       --tomoscan-prefix TOMOSCAN_PREFIX
                             The tomoscan prefix, i.e.'7bmb1:' or '2bma:TomoScan:' (default: 7bmb1:)
-      --url URL             URL address of the scheduling system REST API' (default: https://mis7.aps.anl.gov:7004)
+      --url URL             URL address of the scheduling system REST API' (default: https://beam-api.aps.anl.gov)
       --config FILE         File name of configuration (default: /Users/decarlo/dmagic.conf)
       --verbose             Verbose output (default: True)
 
@@ -126,14 +114,14 @@ To access all options::
 
     (dm) $ dmagic tag -h
     usage: dmagic tag [-h] [--beamline BEAMLINE] [--set SET] [--tomoscan-prefix TOMOSCAN_PREFIX] [--url URL] [--config FILE] [--verbose]
-    
+
     optional arguments:
       -h, --help            show this help message and exit
       --beamline BEAMLINE   beamline name as defined at https://www.aps.anl.gov/Beamlines/Directory, e.g. 2-BM-A,B or 7-BM-B or 32-ID-B,C (default: 7-BM-B)
       --set SET             Number of +/- number days for the current date. Used for setting user info for past/future user groups (default: 0)
       --tomoscan-prefix TOMOSCAN_PREFIX
                             The tomoscan prefix, i.e.'7bmb1:' or '2bma:TomoScan:' (default: 7bmb1:)
-      --url URL             URL address of the scheduling system REST API' (default: https://mis7.aps.anl.gov:7004)
+      --url URL             URL address of the scheduling system REST API' (default: https://beam-api.aps.anl.gov)
       --config FILE         File name of configuration (default: /Users/decarlo/dmagic.conf)
       --verbose             Verbose output (default: True)
 


### PR DESCRIPTION
- README.txt: added full description of what dmagic does, its commands, workflow and use case (project URL kept on first line)
- about.rst: replaced stale Globus integration reference with an accurate description of dmagic's current purpose and architecture
- install.rst: corrected requirements path (env/ -> envs/), updated API URL default to https://beam-api.aps.anl.gov, removed obsolete dependencies (decorator, numpy) from the Dependencies section
- usage.rst: updated API URL throughout, fixed show output (replaced placeholder "s" values with realistic datetime strings, added missing Start date line), fixed tag output to match current per-field log format ("Updating <field> EPICS PV with:"), removed stray shell prompt line from show -h block
- api/dmagic.scheduling.rst: added get_proposal_starting_date to the autosummary list to match the current scheduling module