### PR TITLE
Fix RTD build: add pytz to doc requirements

### DIFF
--- a/envs/requirements-doc.txt
+++ b/envs/requirements-doc.txt
@@ -4,3 +4,4 @@ sphinxcontrib-bibtex >=2, <3
 nbsphinx
 pandoc
 jupyter
+pytz


### PR DESCRIPTION
dmagic/__init__.py imports from dmagic.scheduling, which imports pytz at the top level. Since RTD only installs envs/requirements-doc.txt, pytz was missing and autodoc crashed on import