### PR TITLE
Add DM experiment management commands (create, delete, email, add/remove-user, daq-start/stop)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -35,6 +35,16 @@ Key Commands
                          all users on a DM experiment. Lists station experiments and
                          prompts for selection.
 
+- dmagic daq-start     : Starts automated real-time file transfer (DAQ) to Sojourner.
+                         The DM system monitors the configured directory on the analysis
+                         machine for new files and transfers them continuously.
+
+- dmagic daq-stop      : Stops all running DAQs for a selected experiment.
+
+- dmagic add-user      : Adds one or more users to an existing DM experiment by badge
+                         number. Prompts interactively if no badges are provided on the
+                         command line.
+
 How It Works
 ------------
 
@@ -44,8 +54,9 @@ How It Works
 4. Extracts PI and experiment metadata from the proposal.
 5. Optionally writes that metadata to EPICS PVs so downstream data acquisition software
    (like TomoScan) can tag collected data with the correct experiment/user info.
-6. Optionally creates a DM experiment on Sojourner and populates it with the users
-   from the scheduling proposal, enabling Globus data access.
+6. Optionally creates a DM experiment on Sojourner, populates it with users from the
+   scheduling proposal, starts automated file transfer (DAQ), and notifies users of
+   their Globus data access link.
 
 Use Case
 --------

--- a/README.txt
+++ b/README.txt
@@ -45,6 +45,9 @@ Key Commands
                          number. Prompts interactively if no badges are provided on the
                          command line.
 
+- dmagic remove-user   : Removes one or more users from an existing DM experiment by
+                         badge number. Shows the current user list before prompting.
+
 How It Works
 ------------
 

--- a/README.txt
+++ b/README.txt
@@ -3,30 +3,40 @@ Project Home Page: http://dmagic.readthedocs.org/
 dmagic (Data Magic) is a tool developed at Argonne National Laboratory for managing
 experiment metadata at APS (Advanced Photon Source) beamlines. It bridges the APS
 scheduling system (which tracks who is running experiments and when) with the EPICS
-control system used to operate beamline equipment.
+control system used to operate beamline equipment, and the APS Data Management (DM)
+system (Sojourner) for experiment and user access management.
 
 Key Commands
 ------------
 
-- dmagic show  : Queries the APS scheduling REST API to display the currently active
-                 experiment's information: PI name, affiliation, email, badge number,
-                 proposal ID/title, and start/end times.
+- dmagic show   : Queries the APS scheduling REST API to display the currently active
+                  experiment's information: PI name, affiliation, email, badge number,
+                  proposal ID/title, and start/end times.
 
-- dmagic tag   : Fetches the same scheduling data and writes it into EPICS Process
-                 Variables (PVs) on the beamline's TomoScan IOC. This populates fields
-                 like UserName, UserEmail, ProposalNumber, ProposalTitle, etc. in real-time.
+- dmagic tag    : Fetches the same scheduling data and writes it into EPICS Process
+                  Variables (PVs) on the beamline's TomoScan IOC. This populates fields
+                  like UserName, UserEmail, ProposalNumber, ProposalTitle, etc. in real-time.
 
-- dmagic init  : Creates a configuration file.
+- dmagic create : Creates a DM experiment on Sojourner and adds all users listed in the
+                  APS scheduling proposal. Lists all beamtimes in the current run and
+                  prompts for selection. Supports --manual mode for commissioning runs.
+
+- dmagic email  : Sends a data-access notification email to all users on the DM experiment,
+                  including a Globus link to the experiment data directory.
+
+- dmagic init   : Creates a configuration file.
 
 How It Works
 ------------
 
 1. Authenticates against the APS scheduling REST API using stored credentials.
 2. Determines the current APS run (e.g., "2024-1") based on the current date.
-3. Finds the proposal scheduled for the current beamline at the current time.
+3. Finds the proposal(s) scheduled for the current beamline in that run.
 4. Extracts PI and experiment metadata from the proposal.
 5. Optionally writes that metadata to EPICS PVs so downstream data acquisition software
    (like TomoScan) can tag collected data with the correct experiment/user info.
+6. Optionally creates a DM experiment on Sojourner and populates it with the users
+   from the scheduling proposal, enabling Globus data access.
 
 Use Case
 --------
@@ -34,4 +44,6 @@ Use Case
 Primarily used at tomography beamlines (e.g., 2-BM, 7-BM, 32-ID) so that when a new
 user group arrives to run their approved experiment, the beamline control system is
 automatically updated with their identity and proposal information, ensuring data files
-are properly attributed without manual entry.
+are properly attributed without manual entry. The DM integration further automates
+creation of data management experiments and notifies users of how to access their data
+via Globus.

--- a/README.txt
+++ b/README.txt
@@ -9,28 +9,37 @@ system (Sojourner) for experiment and user access management.
 Key Commands
 ------------
 
-- dmagic show   : Queries the APS scheduling REST API to display the currently active
-                  experiment's information: PI name, affiliation, email, badge number,
-                  proposal ID/title, and start/end times.
+- dmagic init          : Creates ~/dmagic.conf with default values for the beamline.
 
-- dmagic tag    : Fetches the same scheduling data and writes it into EPICS Process
-                  Variables (PVs) on the beamline's TomoScan IOC. This populates fields
-                  like UserName, UserEmail, ProposalNumber, ProposalTitle, etc. in real-time.
+- dmagic show          : Queries the APS scheduling REST API to display the currently
+                         active experiment's information: PI name, affiliation, email,
+                         badge number, proposal ID/title, and start/end times.
 
-- dmagic create : Creates a DM experiment on Sojourner and adds all users listed in the
-                  APS scheduling proposal. Lists all beamtimes in the current run and
-                  prompts for selection. Supports --manual mode for commissioning runs.
+- dmagic tag           : Fetches the same scheduling data and writes it into EPICS
+                         Process Variables (PVs) on the beamline's TomoScan IOC.
+                         Populates UserName, UserEmail, ProposalNumber, ProposalTitle, etc.
 
-- dmagic email  : Sends a data-access notification email to all users on the DM experiment,
-                  including a Globus link to the experiment data directory.
+- dmagic create        : Creates a DM experiment on Sojourner for a proposal-based
+                         beamtime. Lists all beamtimes in the current run, prompts for
+                         selection, then creates the experiment and adds all proposal users.
 
-- dmagic init   : Creates a configuration file.
+- dmagic create-manual : Creates a DM experiment manually for commissioning runs or
+                         staff experiments that have no scheduling proposal. Badge numbers,
+                         PI name, and title are provided on the command line.
+
+- dmagic delete        : Deletes a DM experiment from Sojourner. Lists all experiments
+                         for the station (last 2 years, including manually created ones)
+                         and requires double confirmation before deleting.
+
+- dmagic email         : Sends a data-access notification email with a Globus link to
+                         all users on a DM experiment. Lists station experiments and
+                         prompts for selection.
 
 How It Works
 ------------
 
 1. Authenticates against the APS scheduling REST API using stored credentials.
-2. Determines the current APS run (e.g., "2024-1") based on the current date.
+2. Determines the current APS run (e.g., "2026-1") based on the current date.
 3. Finds the proposal(s) scheduled for the current beamline in that run.
 4. Extracts PI and experiment metadata from the proposal.
 5. Optionally writes that metadata to EPICS PVs so downstream data acquisition software
@@ -44,6 +53,5 @@ Use Case
 Primarily used at tomography beamlines (e.g., 2-BM, 7-BM, 32-ID) so that when a new
 user group arrives to run their approved experiment, the beamline control system is
 automatically updated with their identity and proposal information, ensuring data files
-are properly attributed without manual entry. The DM integration further automates
-creation of data management experiments and notifies users of how to access their data
-via Globus.
+are properly attributed without manual entry. The DM integration automates creation of
+data management experiments and notifies users of how to access their data via Globus.

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -332,9 +332,26 @@ def delete(args):
     args.gup_title   = bt['gup_title']
 
     exp_name = dm.make_experiment_name(args)
-    log.warning('*** This will permanently delete the DM experiment and its data! ***')
-    log.info('   Experiment : %s' % exp_name)
-    if not message.yes_or_no('   *** Confirm deletion? Yes or No'):
+
+    # Fetch experiment details to show storage info before confirming
+    exp_obj = dm.get_experiment(exp_name)
+    if exp_obj is None:
+        log.error('DM experiment not found: %s' % exp_name)
+        log.error('Has dmagic create been run for this proposal?')
+        return
+
+    log.warning('=' * 60)
+    log.warning('*** PERMANENT DELETION — THIS CANNOT BE UNDONE ***')
+    log.info('   Experiment     : %s' % exp_name)
+    log.info('   Storage dir    : %s' % exp_obj.get('storageDirectory', 'N/A'))
+    log.info('   Data dir       : %s' % exp_obj.get('dataDirectory', 'N/A'))
+    log.info('   Analysis dir   : %s' % exp_obj.get('analysisDirectory', 'N/A'))
+    log.warning('=' * 60)
+
+    if not message.yes_or_no('   *** Are you sure? Yes or No'):
+        log.info('   Aborted.')
+        return
+    if not message.yes_or_no('   *** Confirm AGAIN to permanently delete all data'):
         log.info('   Aborted.')
         return
 

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -387,6 +387,54 @@ def email(args):
     message.send_email(args)
 
 
+def _select_experiment(args, prompt_verb):
+    """Show the DM experiment list and return the selected experiment name, or None."""
+    exps = dm.list_experiments_by_station(args.experiment_type)
+    if not exps:
+        log.error('No DM experiments found for station %s.' % args.experiment_type)
+        return None
+    log.info('Found %d DM experiment(s) for station %s:' % (len(exps), args.experiment_type))
+    for i, e in enumerate(exps):
+        start = e.get('startDate', '?')[:10]
+        end   = e.get('endDate',   '?')[:10]
+        desc  = e.get('description', '')[:60]
+        print("  [%2d] %-35s  %s to %s  %s" % (i, e['name'], start, end, desc))
+    while True:
+        try:
+            choice = input("\nSelect experiment to %s [0-%d] or 'q' to quit: " % (
+                           prompt_verb, len(exps) - 1)).strip()
+            if choice.lower() == 'q':
+                log.info('No experiment selected. Exiting.')
+                return None
+            choice = int(choice)
+            if 0 <= choice < len(exps):
+                return exps[choice]['name']
+            print("Please enter a number between 0 and %d" % (len(exps) - 1))
+        except (ValueError, EOFError):
+            print("Invalid input. Please enter a number or 'q' to quit.")
+
+
+def start_daq(args):
+    """
+    Select a DM experiment and start automated real-time file transfer (DAQ) to Sojourner.
+    The DM system will monitor the analysis machine directory for new files and transfer them.
+    """
+    exp_name = _select_experiment(args, 'start DAQ for')
+    if exp_name is None:
+        return
+    dm.start_daq(exp_name, args.analysis, args.analysis_top_dir)
+
+
+def stop_daq(args):
+    """
+    Select a DM experiment and stop all running DAQs for it.
+    """
+    exp_name = _select_experiment(args, 'stop DAQ for')
+    if exp_name is None:
+        return
+    dm.stop_daq(exp_name)
+
+
 def tag(args):
     """
     Update the EPICS PVs with user and experiment information associated with the current experiment
@@ -497,6 +545,8 @@ def main():
         ('create-manual', create_manual, config.MANUAL_PARAMS, config.SITE_SUPPRESS, "Create a DM experiment manually for commissioning runs"),
         ('delete',        delete,        config.CREATE_PARAMS, config.SITE_SUPPRESS, "Delete a DM experiment from Sojourner"),
         ('email',         email,         config.EMAIL_PARAMS,  config.SITE_SUPPRESS, "Send data-access email with Globus link to all users on the DM experiment"),
+        ('daq-start',     start_daq,     config.DAQ_PARAMS,    config.SITE_SUPPRESS, "Start automated real-time file transfer (DAQ) to Sojourner"),
+        ('daq-stop',      stop_daq,      config.DAQ_PARAMS,    config.SITE_SUPPRESS, "Stop all running file transfers for the current experiment"),
     ]
 
     subparsers = parser.add_subparsers(title="Commands", metavar='')
@@ -516,6 +566,10 @@ def main():
 
     args = config.parse_known_args(parser, subparser=True)
 
+    if not hasattr(args, '_func'):
+        parser.print_help()
+        sys.exit(0)
+
     try:
         args._func(args)
         config.log_values(args)
@@ -532,6 +586,8 @@ def main():
             write_sections = ('site',)
         elif cmd == 'create-manual':
             write_sections = ('manual',)
+        elif cmd in ('daq-start', 'daq-stop'):
+            write_sections = ('local',)
         else:
             write_sections = ('settings',)
         config.write(args.config, args=args, sections=write_sections)

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -350,9 +350,37 @@ def delete(args):
 
 def email(args):
     """
-    Send a data-access email with Globus link to all users on the DM experiment.
+    Send a data-access email with Globus link to all users on a DM experiment.
+    Lists all station experiments so the operator can select one.
     """
-    log.info('Sending e-mail to users on the DM experiment')
+    exps = dm.list_experiments_by_station(args.experiment_type)
+    if not exps:
+        log.error('No DM experiments found for station %s.' % args.experiment_type)
+        return
+    log.info('Found %d DM experiment(s) for station %s:' % (len(exps), args.experiment_type))
+    for i, e in enumerate(exps):
+        start = e.get('startDate', '?')[:10]
+        end   = e.get('endDate',   '?')[:10]
+        desc  = e.get('description', '')[:60]
+        print("  [%2d] %-35s  %s to %s  %s" % (i, e['name'], start, end, desc))
+    while True:
+        try:
+            choice = input("\nSelect experiment to email [0-%d] or 'q' to quit: " % (
+                           len(exps) - 1)).strip()
+            if choice.lower() == 'q':
+                log.info('No experiment selected. Exiting.')
+                return
+            choice = int(choice)
+            if 0 <= choice < len(exps):
+                break
+            print("Please enter a number between 0 and %d" % (len(exps) - 1))
+        except (ValueError, EOFError):
+            print("Invalid input. Please enter a number or 'q' to quit.")
+
+    args._exp_name   = exps[choice]['name']
+    args._year_month = exps[choice].get('rootPath', '')
+
+    log.info('Sending e-mail to users on the DM experiment: %s' % args._exp_name)
     args.msg = message.message(args)
     log.info('   Message to users:')
     log.info('   *** %s' % args.msg.get_content())

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -414,6 +414,33 @@ def _select_experiment(args, prompt_verb):
             print("Invalid input. Please enter a number or 'q' to quit.")
 
 
+def add_user(args):
+    """
+    Add one or more users to an existing DM experiment by badge number.
+    Lists all station experiments so the operator can select one.
+    """
+    exp_name = _select_experiment(args, 'add users to')
+    if exp_name is None:
+        return
+
+    if not args.badges:
+        log.error('No badge numbers provided. Use --badges <badge1,badge2,...>')
+        return
+
+    exp_obj = dm.get_experiment(exp_name)
+    if exp_obj is None:
+        log.error('DM experiment not found: %s' % exp_name)
+        return
+
+    username_list = set()
+    for badge in args.badges.split(','):
+        badge = badge.strip()
+        if badge:
+            username_list.add('d' + badge)
+
+    dm.add_users(exp_obj, username_list)
+
+
 def start_daq(args):
     """
     Select a DM experiment and start automated real-time file transfer (DAQ) to Sojourner.
@@ -547,6 +574,7 @@ def main():
         ('email',         email,         config.EMAIL_PARAMS,  config.SITE_SUPPRESS, "Send data-access email with Globus link to all users on the DM experiment"),
         ('daq-start',     start_daq,     config.DAQ_PARAMS,    config.SITE_SUPPRESS, "Start automated real-time file transfer (DAQ) to Sojourner"),
         ('daq-stop',      stop_daq,      config.DAQ_PARAMS,    config.SITE_SUPPRESS, "Stop all running file transfers for the current experiment"),
+        ('add-user',      add_user,      config.CREATE_PARAMS, config.SITE_SUPPRESS, "Add users to an existing DM experiment by badge number"),
     ]
 
     subparsers = parser.add_subparsers(title="Commands", metavar='')
@@ -562,6 +590,10 @@ def main():
                      'experiments created with "dmagic create-manual" that are not in the '
                      'APS scheduling system (e.g. 2026-03-Staff-0). Leave blank to select '
                      'from the list of all station experiments.')
+        if cmd == 'add-user':
+            cmd_parser.add_argument(
+                '--badges', default='', type=str, metavar='BADGES',
+                help='Comma-separated badge number(s) to add to the experiment (e.g. 12345 or 12345,67890)')
         cmd_parser.set_defaults(_func=func)
 
     args = config.parse_known_args(parser, subparser=True)

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -293,9 +293,9 @@ def delete(args):
     can select one, then deletes it after double confirmation.
     Use --name to bypass the list and delete a known experiment directly.
     """
-    if getattr(args, 'name', None):
+    if getattr(args, 'exp_name', None):
         # Direct lookup by name (useful for manually created experiments)
-        exp_name = args.name
+        exp_name = args.exp_name
     else:
         exps = dm.list_experiments_by_station(args.experiment_type)
         if not exps:
@@ -479,7 +479,7 @@ def main():
         cmd_parser = cmd_params.add_arguments(cmd_parser)
         if cmd == 'delete':
             cmd_parser.add_argument(
-                '--name', default=None, type=str, metavar='EXP_NAME',
+                '--exp-name', default=None, type=str, metavar='EXP_NAME',
                 help='[Optional] Full DM experiment name, used only to delete commissioning '
                      'experiments created with "dmagic create-manual" that are not in the '
                      'APS scheduling system (e.g. 2026-03-Staff-0). Leave blank to select '

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -67,6 +67,8 @@ from dmagic import log
 from dmagic import config
 from dmagic import authorize
 from dmagic import utils
+from dmagic import dm
+from dmagic import message
 
 
 def init_PVs(args):
@@ -161,6 +163,125 @@ def show(args):
     else:
         time_now = datetime.datetime.now().astimezone() + dt.timedelta(args.set)
         log.warning('No proposal run on %s during %s' % (time_now, run))
+
+
+def create(args):
+    """
+    Create a DM experiment on Sojourner and add users from the scheduling system.
+
+    In normal mode, lists all beamtimes in the current run, lets the operator
+    select one interactively, then creates the DM experiment and adds all users
+    from the proposal. In --manual mode, uses the badge list and metadata
+    supplied on the command line / config file.
+    """
+    if args.manual:
+        now = datetime.datetime.now()
+        if args.date:
+            try:
+                ref_date = datetime.datetime.strptime(args.date, '%Y-%m')
+            except ValueError:
+                log.error("Invalid --date '%s': expected format is yyyy-mm (e.g. 2025-12)" % args.date)
+                return
+        else:
+            ref_date = now
+        args.year_month     = ref_date.strftime('%Y-%m')
+        args.pi_last_name   = args.name
+        args.pi_first_name  = args.first_name
+        args.pi_institution = args.institution
+        args.pi_email       = args.email
+        args.pi_badge       = ''
+        args.gup_number     = '0'
+        args.gup_title      = args.title
+        args.manual_start   = ref_date.strftime('%d-%b-%y')
+        args.manual_end     = (ref_date + dt.timedelta(days=14)).strftime('%d-%b-%y')
+        log.info("Manual experiment: %s-%s, title: %s" % (
+                  args.year_month, args.pi_last_name, args.gup_title))
+    else:
+        auth = authorize.basic(args.credentials)
+        if auth is None:
+            return
+        beamtimes = scheduling.list_beamtimes(auth, args)
+        if not beamtimes:
+            log.error("No beamtimes found for the current run")
+            return
+        elif len(beamtimes) == 1:
+            bt = beamtimes[0]
+            log.info("Found 1 beamtime in run %s: GUP %s (PI: %s, %s)" % (
+                      bt['run_name'], bt['gup_number'], bt['pi_last_name'],
+                      bt['gup_title'][:60]))
+        else:
+            log.info("Found %d beamtimes in run %s:" % (
+                      len(beamtimes), beamtimes[0]['run_name']))
+            for i, bt in enumerate(beamtimes):
+                print("  [%d] GUP %s - PI: %s - %s" % (
+                      i, bt['gup_number'], bt['pi_last_name'], bt['gup_title'][:70]))
+                print("       %s to %s" % (bt['start_time'], bt['end_time']))
+            while True:
+                try:
+                    choice = input("\nSelect beamtime [0-%d] or 'q' to quit: " % (
+                                   len(beamtimes) - 1)).strip()
+                    if choice.lower() == 'q':
+                        log.info("No beamtime selected. Exiting.")
+                        return
+                    choice = int(choice)
+                    if 0 <= choice < len(beamtimes):
+                        bt = beamtimes[choice]
+                        break
+                    print("Please enter a number between 0 and %d" % (len(beamtimes) - 1))
+                except (ValueError, EOFError):
+                    print("Invalid input. Please enter a number or 'q' to quit.")
+
+        args.year_month     = bt['year_month']
+        args.pi_last_name   = bt['pi_last_name']
+        args.pi_first_name  = bt['pi_first_name']
+        args.pi_institution = bt['pi_institution']
+        args.pi_email       = bt['pi_email']
+        args.pi_badge       = bt['pi_badge']
+        args.gup_number     = bt['gup_number']
+        args.gup_title      = bt['gup_title']
+
+    exp_name = dm.make_experiment_name(args)
+    log.info('Create summary:')
+    log.info('   Experiment : %s/%s' % (args.year_month, exp_name))
+    log.info('   Title      : %s' % args.gup_title)
+    if not message.yes_or_no('   *** Confirm? Yes or No'):
+        log.info('   Aborted.')
+        return
+
+    new_exp = dm.create_experiment(args)
+    if new_exp is None:
+        return
+
+    if args.manual:
+        user_list = {'d' + str(args.primary_beamline_contact_badge),
+                     'd' + str(args.secondary_beamline_contact_badge)}
+        if args.badges:
+            for badge in args.badges.split(','):
+                badge = badge.strip()
+                if badge:
+                    user_list.add('d' + badge)
+        log.info('Adding manual users to the DM experiment.')
+    else:
+        user_list = dm.make_dm_username_list(args)
+        if user_list is None:
+            log.warning("   GUP %s not found in the scheduling system." % args.gup_number)
+            log.warning("   DM experiment '%s' was created but no users were added." % exp_name)
+            log.info("   To add a user run: dmagic add-user --badge <badge#>")
+            return
+        log.info('Adding users from the current proposal to the DM experiment.')
+
+    dm.add_users(new_exp, user_list)
+
+
+def email(args):
+    """
+    Send a data-access email with Globus link to all users on the DM experiment.
+    """
+    log.info('Sending e-mail to users on the DM experiment')
+    args.msg = message.message(args)
+    log.info('   Message to users:')
+    log.info('   *** %s' % args.msg.get_content())
+    message.send_email(args)
 
 
 def tag(args):
@@ -263,13 +384,16 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', **config.SECTIONS['general']['config'])
-    show_params = config.DMAGIC_PARAMS
-    tag_params = config.DMAGIC_PARAMS
+    show_params   = config.DMAGIC_PARAMS
+    tag_params    = config.DMAGIC_PARAMS
+    dm_params     = config.DM_PARAMS
 
     cmd_parsers = [
         ('init',        init,           (),                             "Create configuration file"),
         ('show',        show,           show_params,                    "Show user and experiment info from the APS schedule"),
         ('tag',         tag,            tag_params,                     "Update user info EPICS PVs with info from the APS schedule"),
+        ('create',      create,         dm_params,                      "Create a DM experiment on Sojourner and add users from the scheduling system"),
+        ('email',       email,          dm_params,                      "Send data-access email with Globus link to all users on the DM experiment"),
     ]
 
     subparsers = parser.add_subparsers(title="Commands", metavar='')

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -414,6 +414,47 @@ def _select_experiment(args, prompt_verb):
             print("Invalid input. Please enter a number or 'q' to quit.")
 
 
+def remove_user(args):
+    """
+    Remove one or more users from an existing DM experiment by badge number.
+    Lists all station experiments so the operator can select one, then shows
+    the current user list before prompting for badge number(s) to remove.
+    """
+    exp_name = _select_experiment(args, 'remove users from')
+    if exp_name is None:
+        return
+
+    exp_obj = dm.get_experiment(exp_name)
+    if exp_obj is None:
+        log.error('DM experiment not found: %s' % exp_name)
+        return
+
+    existing = exp_obj.get('experimentUsernameList', [])
+    if existing:
+        log.info('Current users on %s:' % exp_name)
+        for u in sorted(existing):
+            log.info('   %s' % u)
+    else:
+        log.info('No users currently on %s' % exp_name)
+
+    if not args.badges:
+        try:
+            args.badges = input('Enter badge number(s) to remove (comma-separated): ').strip()
+        except EOFError:
+            args.badges = ''
+    if not args.badges:
+        log.error('No badge numbers provided.')
+        return
+
+    username_list = set()
+    for badge in args.badges.split(','):
+        badge = badge.strip()
+        if badge:
+            username_list.add('d' + badge)
+
+    dm.remove_users(exp_name, username_list)
+
+
 def add_user(args):
     """
     Add one or more users to an existing DM experiment by badge number.
@@ -580,6 +621,7 @@ def main():
         ('daq-start',     start_daq,     config.DAQ_PARAMS,    config.SITE_SUPPRESS, "Start automated real-time file transfer (DAQ) to Sojourner"),
         ('daq-stop',      stop_daq,      config.DAQ_PARAMS,    config.SITE_SUPPRESS, "Stop all running file transfers for the current experiment"),
         ('add-user',      add_user,      config.CREATE_PARAMS, config.SITE_SUPPRESS, "Add users to an existing DM experiment by badge number"),
+        ('remove-user',   remove_user,   config.CREATE_PARAMS, config.SITE_SUPPRESS, "Remove users from an existing DM experiment by badge number"),
     ]
 
     subparsers = parser.add_subparsers(title="Commands", metavar='')
@@ -595,10 +637,10 @@ def main():
                      'experiments created with "dmagic create-manual" that are not in the '
                      'APS scheduling system (e.g. 2026-03-Staff-0). Leave blank to select '
                      'from the list of all station experiments.')
-        if cmd == 'add-user':
+        if cmd in ('add-user', 'remove-user'):
             cmd_parser.add_argument(
                 '--badges', default='', type=str, metavar='BADGES',
-                help='Comma-separated badge number(s) to add to the experiment (e.g. 12345 or 12345,67890)')
+                help='Comma-separated badge number(s) to add/remove (e.g. 12345 or 12345,67890)')
         cmd_parser.set_defaults(_func=func)
 
     args = config.parse_known_args(parser, subparser=True)

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -388,22 +388,20 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', **config.SECTIONS['general']['config'])
-    show_params   = config.DMAGIC_PARAMS
-    tag_params    = config.DMAGIC_PARAMS
-    dm_params     = config.DM_PARAMS
 
+    # (sections shown in -h, sections suppressed in -h but still parsed, help text)
     cmd_parsers = [
-        ('init',        init,           (),                             "Create configuration file"),
-        ('show',        show,           show_params,                    "Show user and experiment info from the APS schedule"),
-        ('tag',         tag,            tag_params,                     "Update user info EPICS PVs with info from the APS schedule"),
-        ('create',      create,         dm_params,                      "Create a DM experiment on Sojourner and add users from the scheduling system"),
-        ('email',       email,          dm_params,                      "Send data-access email with Globus link to all users on the DM experiment"),
+        ('init',   init,   config.INIT_PARAMS,   (),                   "Create configuration file"),
+        ('show',   show,   config.SHOW_PARAMS,   config.SITE_SUPPRESS, "Show user and experiment info from the APS schedule"),
+        ('tag',    tag,    config.TAG_PARAMS,    config.SITE_SUPPRESS, "Update user info EPICS PVs with info from the APS schedule"),
+        ('create', create, config.CREATE_PARAMS, config.SITE_SUPPRESS, "Create a DM experiment on Sojourner and add users from the scheduling system"),
+        ('email',  email,  config.EMAIL_PARAMS,  config.SITE_SUPPRESS, "Send data-access email with Globus link to all users on the DM experiment"),
     ]
 
     subparsers = parser.add_subparsers(title="Commands", metavar='')
 
-    for cmd, func, sections, text in cmd_parsers:
-        cmd_params = config.Params(sections=sections)
+    for cmd, func, sections, suppress, text in cmd_parsers:
+        cmd_params = config.Params(sections=sections, suppress_sections=suppress)
         cmd_parser = subparsers.add_parser(cmd, help=text, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         cmd_parser = cmd_params.add_arguments(cmd_parser)
         cmd_parser.set_defaults(_func=func)
@@ -411,12 +409,17 @@ def main():
     args = config.parse_known_args(parser, subparser=True)
 
     try:
-        # load args from default (config.py) if not changed
         args._func(args)
         config.log_values(args)
-        # undate globus.config file
-        sections = config.DMAGIC_PARAMS
-        config.write(args.config, args=args, sections=sections)
+        # Write sections appropriate to each command
+        cmd = sys.argv[1] if len(sys.argv) > 1 else ''
+        if cmd == 'init':
+            write_sections = ('site',)
+        elif cmd == 'create':
+            write_sections = ('settings', 'create')
+        else:
+            write_sections = ('settings',)
+        config.write(args.config, args=args, sections=write_sections)
     except RuntimeError as e:
         log.error(str(e))
         sys.exit(1)

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -286,6 +286,61 @@ def create_manual(args):
     _finish_create(args, dm.make_experiment_name(args))
 
 
+def delete(args):
+    """
+    Delete a DM experiment from Sojourner.
+    Lists all beamtimes in the current run, lets the operator select one,
+    then deletes the corresponding DM experiment after confirmation.
+    """
+    auth = authorize.basic(args.credentials)
+    if auth is None:
+        return
+    beamtimes = scheduling.list_beamtimes(auth, args)
+    if not beamtimes:
+        log.error("No beamtimes found for the current run")
+        return
+    elif len(beamtimes) == 1:
+        bt = beamtimes[0]
+        log.info("Found 1 beamtime in run %s: GUP %s (PI: %s, %s)" % (
+                  bt['run_name'], bt['gup_number'], bt['pi_last_name'],
+                  bt['gup_title'][:60]))
+    else:
+        log.info("Found %d beamtimes in run %s:" % (
+                  len(beamtimes), beamtimes[0]['run_name']))
+        for i, bt in enumerate(beamtimes):
+            print("  [%d] GUP %s - PI: %s - %s" % (
+                  i, bt['gup_number'], bt['pi_last_name'], bt['gup_title'][:70]))
+            print("       %s to %s" % (bt['start_time'], bt['end_time']))
+        while True:
+            try:
+                choice = input("\nSelect beamtime [0-%d] or 'q' to quit: " % (
+                               len(beamtimes) - 1)).strip()
+                if choice.lower() == 'q':
+                    log.info("No beamtime selected. Exiting.")
+                    return
+                choice = int(choice)
+                if 0 <= choice < len(beamtimes):
+                    bt = beamtimes[choice]
+                    break
+                print("Please enter a number between 0 and %d" % (len(beamtimes) - 1))
+            except (ValueError, EOFError):
+                print("Invalid input. Please enter a number or 'q' to quit.")
+
+    args.year_month  = bt['year_month']
+    args.pi_last_name = bt['pi_last_name']
+    args.gup_number  = bt['gup_number']
+    args.gup_title   = bt['gup_title']
+
+    exp_name = dm.make_experiment_name(args)
+    log.warning('*** This will permanently delete the DM experiment and its data! ***')
+    log.info('   Experiment : %s' % exp_name)
+    if not message.yes_or_no('   *** Confirm deletion? Yes or No'):
+        log.info('   Aborted.')
+        return
+
+    dm.delete_experiment(args)
+
+
 def email(args):
     """
     Send a data-access email with Globus link to all users on the DM experiment.
@@ -405,6 +460,7 @@ def main():
         ('tag',           tag,           config.TAG_PARAMS,    config.SITE_SUPPRESS, "Update user info EPICS PVs with info from the APS schedule"),
         ('create',        create,        config.CREATE_PARAMS, config.SITE_SUPPRESS, "Create a DM experiment from the APS scheduling system"),
         ('create-manual', create_manual, config.MANUAL_PARAMS, config.SITE_SUPPRESS, "Create a DM experiment manually for commissioning runs"),
+        ('delete',        delete,        config.CREATE_PARAMS, config.SITE_SUPPRESS, "Delete a DM experiment from Sojourner"),
         ('email',         email,         config.EMAIL_PARAMS,  config.SITE_SUPPRESS, "Send data-access email with Globus link to all users on the DM experiment"),
     ]
 

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -206,7 +206,7 @@ def create(args):
         log.info("Found %d beamtimes in run %s:" % (
                   len(beamtimes), beamtimes[0]['run_name']))
         for i, bt in enumerate(beamtimes):
-            print("  [%d] GUP %s - PI: %s - %s" % (
+            print("  [%2d] GUP %s - PI: %s - %s" % (
                   i, bt['gup_number'], bt['pi_last_name'], bt['gup_title'][:70]))
             print("       %s to %s" % (bt['start_time'], bt['end_time']))
         while True:
@@ -307,7 +307,7 @@ def delete(args):
             start = e.get('startDate', '?')[:10]
             end   = e.get('endDate',   '?')[:10]
             desc  = e.get('description', '')[:60]
-            print("  [%d] %-35s  %s to %s  %s" % (i, e['name'], start, end, desc))
+            print("  [%2d] %-35s  %s to %s  %s" % (i, e['name'], start, end, desc))
         while True:
             try:
                 choice = input("\nSelect experiment to delete [0-%d] or 'q' to quit: " % (

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -289,51 +289,41 @@ def create_manual(args):
 def delete(args):
     """
     Delete a DM experiment from Sojourner.
-    Lists all beamtimes in the current run, lets the operator select one,
-    then deletes the corresponding DM experiment after confirmation.
+    Lists all DM experiments for this station (last 2 years) so the operator
+    can select one, then deletes it after double confirmation.
+    Use --name to bypass the list and delete a known experiment directly.
     """
-    auth = authorize.basic(args.credentials)
-    if auth is None:
-        return
-    beamtimes = scheduling.list_beamtimes(auth, args)
-    if not beamtimes:
-        log.error("No beamtimes found for the current run")
-        return
-    elif len(beamtimes) == 1:
-        bt = beamtimes[0]
-        log.info("Found 1 beamtime in run %s: GUP %s (PI: %s, %s)" % (
-                  bt['run_name'], bt['gup_number'], bt['pi_last_name'],
-                  bt['gup_title'][:60]))
+    if getattr(args, 'name', None):
+        # Direct lookup by name (useful for manually created experiments)
+        exp_name = args.name
     else:
-        log.info("Found %d beamtimes in run %s:" % (
-                  len(beamtimes), beamtimes[0]['run_name']))
-        for i, bt in enumerate(beamtimes):
-            print("  [%d] GUP %s - PI: %s - %s" % (
-                  i, bt['gup_number'], bt['pi_last_name'], bt['gup_title'][:70]))
-            print("       %s to %s" % (bt['start_time'], bt['end_time']))
+        exps = dm.list_experiments_by_station(args.experiment_type)
+        if not exps:
+            log.error('No DM experiments found for station %s (last 2 years).' % args.experiment_type)
+            log.error('Use --name EXP_NAME to specify an experiment name directly.')
+            return
+        log.info('Found %d DM experiment(s) for station %s:' % (len(exps), args.experiment_type))
+        for i, e in enumerate(exps):
+            start = e.get('startDate', '?')[:10]
+            end   = e.get('endDate',   '?')[:10]
+            desc  = e.get('description', '')[:60]
+            print("  [%d] %-35s  %s to %s  %s" % (i, e['name'], start, end, desc))
         while True:
             try:
-                choice = input("\nSelect beamtime [0-%d] or 'q' to quit: " % (
-                               len(beamtimes) - 1)).strip()
+                choice = input("\nSelect experiment to delete [0-%d] or 'q' to quit: " % (
+                               len(exps) - 1)).strip()
                 if choice.lower() == 'q':
-                    log.info("No beamtime selected. Exiting.")
+                    log.info('No experiment selected. Exiting.')
                     return
                 choice = int(choice)
-                if 0 <= choice < len(beamtimes):
-                    bt = beamtimes[choice]
+                if 0 <= choice < len(exps):
+                    exp_name = exps[choice]['name']
                     break
-                print("Please enter a number between 0 and %d" % (len(beamtimes) - 1))
+                print("Please enter a number between 0 and %d" % (len(exps) - 1))
             except (ValueError, EOFError):
                 print("Invalid input. Please enter a number or 'q' to quit.")
 
-    args.year_month  = bt['year_month']
-    args.pi_last_name = bt['pi_last_name']
-    args.gup_number  = bt['gup_number']
-    args.gup_title   = bt['gup_title']
-
-    exp_name = dm.make_experiment_name(args)
-
-    # Fetch experiment details to show storage info before confirming
+    # Fetch full experiment object for storage path details
     exp_obj = dm.get_experiment(exp_name)
     if exp_obj is None:
         log.error('DM experiment not found: %s' % exp_name)
@@ -355,7 +345,7 @@ def delete(args):
         log.info('   Aborted.')
         return
 
-    dm.delete_experiment(args)
+    dm.delete_experiment(exp_name)
 
 
 def email(args):
@@ -487,6 +477,13 @@ def main():
         cmd_params = config.Params(sections=sections, suppress_sections=suppress)
         cmd_parser = subparsers.add_parser(cmd, help=text, description=text, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         cmd_parser = cmd_params.add_arguments(cmd_parser)
+        if cmd == 'delete':
+            cmd_parser.add_argument(
+                '--name', default=None, type=str, metavar='EXP_NAME',
+                help='[Optional] Full DM experiment name, used only to delete commissioning '
+                     'experiments created with "dmagic create-manual" that are not in the '
+                     'APS scheduling system (e.g. 2026-03-Staff-0). Leave blank to select '
+                     'from the list of all station experiments.')
         cmd_parser.set_defaults(_func=func)
 
     args = config.parse_known_args(parser, subparser=True)

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -424,7 +424,12 @@ def add_user(args):
         return
 
     if not args.badges:
-        log.error('No badge numbers provided. Use --badges <badge1,badge2,...>')
+        try:
+            args.badges = input('Enter badge number(s) to add (comma-separated): ').strip()
+        except EOFError:
+            args.badges = ''
+    if not args.badges:
+        log.error('No badge numbers provided.')
         return
 
     exp_obj = dm.get_experiment(exp_name)

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -413,7 +413,7 @@ def main():
 
     for cmd, func, sections, suppress, text in cmd_parsers:
         cmd_params = config.Params(sections=sections, suppress_sections=suppress)
-        cmd_parser = subparsers.add_parser(cmd, help=text, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+        cmd_parser = subparsers.add_parser(cmd, help=text, description=text, formatter_class=argparse.ArgumentDefaultsHelpFormatter)
         cmd_parser = cmd_params.add_arguments(cmd_parser)
         cmd_parser.set_defaults(_func=func)
 

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -165,82 +165,8 @@ def show(args):
         log.warning('No proposal run on %s during %s' % (time_now, run))
 
 
-def create(args):
-    """
-    Create a DM experiment on Sojourner and add users from the scheduling system.
-
-    In normal mode, lists all beamtimes in the current run, lets the operator
-    select one interactively, then creates the DM experiment and adds all users
-    from the proposal. In --manual mode, uses the badge list and metadata
-    supplied on the command line / config file.
-    """
-    if args.manual:
-        now = datetime.datetime.now()
-        if args.date:
-            try:
-                ref_date = datetime.datetime.strptime(args.date, '%Y-%m')
-            except ValueError:
-                log.error("Invalid --date '%s': expected format is yyyy-mm (e.g. 2025-12)" % args.date)
-                return
-        else:
-            ref_date = now
-        args.year_month     = ref_date.strftime('%Y-%m')
-        args.pi_last_name   = args.name
-        args.pi_first_name  = args.first_name
-        args.pi_institution = args.institution
-        args.pi_email       = args.email
-        args.pi_badge       = ''
-        args.gup_number     = '0'
-        args.gup_title      = args.title
-        args.manual_start   = ref_date.strftime('%d-%b-%y')
-        args.manual_end     = (ref_date + dt.timedelta(days=14)).strftime('%d-%b-%y')
-        log.info("Manual experiment: %s-%s, title: %s" % (
-                  args.year_month, args.pi_last_name, args.gup_title))
-    else:
-        auth = authorize.basic(args.credentials)
-        if auth is None:
-            return
-        beamtimes = scheduling.list_beamtimes(auth, args)
-        if not beamtimes:
-            log.error("No beamtimes found for the current run")
-            return
-        elif len(beamtimes) == 1:
-            bt = beamtimes[0]
-            log.info("Found 1 beamtime in run %s: GUP %s (PI: %s, %s)" % (
-                      bt['run_name'], bt['gup_number'], bt['pi_last_name'],
-                      bt['gup_title'][:60]))
-        else:
-            log.info("Found %d beamtimes in run %s:" % (
-                      len(beamtimes), beamtimes[0]['run_name']))
-            for i, bt in enumerate(beamtimes):
-                print("  [%d] GUP %s - PI: %s - %s" % (
-                      i, bt['gup_number'], bt['pi_last_name'], bt['gup_title'][:70]))
-                print("       %s to %s" % (bt['start_time'], bt['end_time']))
-            while True:
-                try:
-                    choice = input("\nSelect beamtime [0-%d] or 'q' to quit: " % (
-                                   len(beamtimes) - 1)).strip()
-                    if choice.lower() == 'q':
-                        log.info("No beamtime selected. Exiting.")
-                        return
-                    choice = int(choice)
-                    if 0 <= choice < len(beamtimes):
-                        bt = beamtimes[choice]
-                        break
-                    print("Please enter a number between 0 and %d" % (len(beamtimes) - 1))
-                except (ValueError, EOFError):
-                    print("Invalid input. Please enter a number or 'q' to quit.")
-
-        args.year_month     = bt['year_month']
-        args.pi_last_name   = bt['pi_last_name']
-        args.pi_first_name  = bt['pi_first_name']
-        args.pi_institution = bt['pi_institution']
-        args.pi_email       = bt['pi_email']
-        args.pi_badge       = bt['pi_badge']
-        args.gup_number     = bt['gup_number']
-        args.gup_title      = bt['gup_title']
-
-    exp_name = dm.make_experiment_name(args)
+def _finish_create(args, exp_name):
+    """Shared tail for create and create-manual: confirm, create experiment, add users, print summary."""
     log.info('Create summary:')
     log.info('   Experiment : %s/%s' % (args.year_month, exp_name))
     log.info('   Title      : %s' % args.gup_title)
@@ -252,29 +178,113 @@ def create(args):
     if new_exp is None:
         return
 
-    if args.manual:
-        user_list = {'d' + str(args.primary_beamline_contact_badge),
-                     'd' + str(args.secondary_beamline_contact_badge)}
-        if args.badges:
-            for badge in args.badges.split(','):
-                badge = badge.strip()
-                if badge:
-                    user_list.add('d' + badge)
-        log.info('Adding manual users to the DM experiment.')
-    else:
-        user_list = dm.make_dm_username_list(args)
-        if user_list is None:
-            log.warning("   GUP %s not found in the scheduling system." % args.gup_number)
-            log.warning("   DM experiment '%s' was created but no users were added." % exp_name)
-            log.info("   To add a user run: dmagic add-user --badge <badge#>")
-            return
-        log.info('Adding users from the current proposal to the DM experiment.')
-
-    dm.add_users(new_exp, user_list)
+    dm.add_users(new_exp, args._user_list)
 
     data_link = dm.make_data_link(args)
     log.info('Experiment name : %s' % exp_name)
     log.info('Globus data link: %s' % data_link)
+
+
+def create(args):
+    """
+    Create a DM experiment on Sojourner from the APS scheduling system.
+    Lists all beamtimes in the current run, lets the operator select one
+    interactively, then creates the DM experiment and adds all proposal users.
+    """
+    auth = authorize.basic(args.credentials)
+    if auth is None:
+        return
+    beamtimes = scheduling.list_beamtimes(auth, args)
+    if not beamtimes:
+        log.error("No beamtimes found for the current run")
+        return
+    elif len(beamtimes) == 1:
+        bt = beamtimes[0]
+        log.info("Found 1 beamtime in run %s: GUP %s (PI: %s, %s)" % (
+                  bt['run_name'], bt['gup_number'], bt['pi_last_name'],
+                  bt['gup_title'][:60]))
+    else:
+        log.info("Found %d beamtimes in run %s:" % (
+                  len(beamtimes), beamtimes[0]['run_name']))
+        for i, bt in enumerate(beamtimes):
+            print("  [%d] GUP %s - PI: %s - %s" % (
+                  i, bt['gup_number'], bt['pi_last_name'], bt['gup_title'][:70]))
+            print("       %s to %s" % (bt['start_time'], bt['end_time']))
+        while True:
+            try:
+                choice = input("\nSelect beamtime [0-%d] or 'q' to quit: " % (
+                               len(beamtimes) - 1)).strip()
+                if choice.lower() == 'q':
+                    log.info("No beamtime selected. Exiting.")
+                    return
+                choice = int(choice)
+                if 0 <= choice < len(beamtimes):
+                    bt = beamtimes[choice]
+                    break
+                print("Please enter a number between 0 and %d" % (len(beamtimes) - 1))
+            except (ValueError, EOFError):
+                print("Invalid input. Please enter a number or 'q' to quit.")
+
+    args.year_month     = bt['year_month']
+    args.pi_last_name   = bt['pi_last_name']
+    args.pi_first_name  = bt['pi_first_name']
+    args.pi_institution = bt['pi_institution']
+    args.pi_email       = bt['pi_email']
+    args.pi_badge       = bt['pi_badge']
+    args.gup_number     = bt['gup_number']
+    args.gup_title      = bt['gup_title']
+
+    user_list = dm.make_dm_username_list(args)
+    exp_name  = dm.make_experiment_name(args)
+    if user_list is None:
+        log.warning("GUP %s not found in the scheduling system." % args.gup_number)
+        log.warning("Experiment '%s' will be created but no users will be added." % exp_name)
+        log.info("To add a user afterwards run: dmagic add-user --badge <badge#>")
+        user_list = set()
+    else:
+        log.info('Adding users from the current proposal to the DM experiment.')
+    args._user_list = user_list
+    _finish_create(args, exp_name)
+
+
+def create_manual(args):
+    """
+    Create a DM experiment manually for commissioning runs without a proposal.
+    Uses PI metadata and badge numbers supplied on the command line.
+    """
+    now = datetime.datetime.now()
+    if args.date:
+        try:
+            ref_date = datetime.datetime.strptime(args.date, '%Y-%m')
+        except ValueError:
+            log.error("Invalid --date '%s': expected format is yyyy-mm (e.g. 2025-12)" % args.date)
+            return
+    else:
+        ref_date = now
+    args.year_month     = ref_date.strftime('%Y-%m')
+    args.pi_last_name   = args.name
+    args.pi_first_name  = args.first_name
+    args.pi_institution = args.institution
+    args.pi_email       = args.email
+    args.pi_badge       = ''
+    args.gup_number     = '0'
+    args.gup_title      = args.title
+    args.manual         = True
+    args.manual_start   = ref_date.strftime('%d-%b-%y')
+    args.manual_end     = (ref_date + dt.timedelta(days=14)).strftime('%d-%b-%y')
+    log.info("Manual experiment: %s-%s, title: %s" % (
+              args.year_month, args.pi_last_name, args.gup_title))
+
+    user_list = {'d' + str(args.primary_beamline_contact_badge),
+                 'd' + str(args.secondary_beamline_contact_badge)}
+    if args.badges:
+        for badge in args.badges.split(','):
+            badge = badge.strip()
+            if badge:
+                user_list.add('d' + badge)
+    log.info('Adding manual users to the DM experiment.')
+    args._user_list = user_list
+    _finish_create(args, dm.make_experiment_name(args))
 
 
 def email(args):
@@ -391,11 +401,12 @@ def main():
 
     # (sections shown in -h, sections suppressed in -h but still parsed, help text)
     cmd_parsers = [
-        ('init',   init,   config.INIT_PARAMS,   (),                   "Create configuration file"),
-        ('show',   show,   config.SHOW_PARAMS,   config.SITE_SUPPRESS, "Show user and experiment info from the APS schedule"),
-        ('tag',    tag,    config.TAG_PARAMS,    config.SITE_SUPPRESS, "Update user info EPICS PVs with info from the APS schedule"),
-        ('create', create, config.CREATE_PARAMS, config.SITE_SUPPRESS, "Create a DM experiment on Sojourner and add users from the scheduling system"),
-        ('email',  email,  config.EMAIL_PARAMS,  config.SITE_SUPPRESS, "Send data-access email with Globus link to all users on the DM experiment"),
+        ('init',          init,          config.INIT_PARAMS,   (),                   "Create configuration file"),
+        ('show',          show,          config.SHOW_PARAMS,   config.SITE_SUPPRESS, "Show user and experiment info from the APS schedule"),
+        ('tag',           tag,           config.TAG_PARAMS,    config.SITE_SUPPRESS, "Update user info EPICS PVs with info from the APS schedule"),
+        ('create',        create,        config.CREATE_PARAMS, config.SITE_SUPPRESS, "Create a DM experiment from the APS scheduling system"),
+        ('create-manual', create_manual, config.MANUAL_PARAMS, config.SITE_SUPPRESS, "Create a DM experiment manually for commissioning runs"),
+        ('email',         email,         config.EMAIL_PARAMS,  config.SITE_SUPPRESS, "Send data-access email with Globus link to all users on the DM experiment"),
     ]
 
     subparsers = parser.add_subparsers(title="Commands", metavar='')
@@ -415,8 +426,8 @@ def main():
         cmd = sys.argv[1] if len(sys.argv) > 1 else ''
         if cmd == 'init':
             write_sections = ('site',)
-        elif cmd == 'create':
-            write_sections = ('settings', 'create')
+        elif cmd == 'create-manual':
+            write_sections = ('manual',)
         else:
             write_sections = ('settings',)
         config.write(args.config, args=args, sections=write_sections)

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -181,8 +181,7 @@ def _finish_create(args, exp_name):
     dm.add_users(new_exp, args._user_list)
 
     data_link = dm.make_data_link(args)
-    log.info('Experiment name : %s' % exp_name)
-    log.info('Globus data link: %s' % data_link)
+    args._final_summary = (exp_name, data_link)
 
 
 def create(args):
@@ -422,6 +421,13 @@ def main():
     try:
         args._func(args)
         config.log_values(args)
+        if hasattr(args, '_final_summary'):
+            exp_name, data_link = args._final_summary
+            sep = '=' * 60
+            log.info(sep)
+            log.info('Experiment name : %s' % exp_name)
+            log.info('Globus data link: %s' % data_link)
+            log.info(sep)
         # Write sections appropriate to each command
         cmd = sys.argv[1] if len(sys.argv) > 1 else ''
         if cmd == 'init':

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -272,6 +272,10 @@ def create(args):
 
     dm.add_users(new_exp, user_list)
 
+    data_link = dm.make_data_link(args)
+    log.info('Experiment name : %s' % exp_name)
+    log.info('Globus data link: %s' % data_link)
+
 
 def email(args):
     """

--- a/dmagic/authorize.py
+++ b/dmagic/authorize.py
@@ -1,4 +1,3 @@
-import pathlib
 from requests.auth import HTTPBasicAuth
 
 from dmagic import log
@@ -10,31 +9,58 @@ __docformat__ = 'restructuredtext en'
 __all__ = ['basic',
           'read_credentials', ]
 
-debug = False
-
 
 def read_credentials(filename):
     """
     Read username and password from filename.
+
+    The file should contain one line in the format: username|password
     """
-    credentials = []
-    with open(filename, 'r') as file:
-        for line in file:
-            username, password = line.strip().split('|')  
-            credentials.append((username, password))
-    return credentials
+    try:
+        with open(filename, 'r') as file:
+            line = file.readline().strip()
+    except FileNotFoundError:
+        log.error('Credentials file not found: %s' % filename)
+        log.error('Create it with: echo "username|password" > %s' % filename)
+        return None
+    except PermissionError:
+        log.error('Permission denied reading credentials file: %s' % filename)
+        return None
+    except Exception as e:
+        log.error('Error reading credentials file %s: %s' % (filename, str(e)))
+        return None
+
+    if not line:
+        log.error('Credentials file is empty: %s' % filename)
+        return None
+
+    parts = line.split('|')
+    if len(parts) != 2:
+        log.error('Invalid credentials format in %s. Expected: username|password' % filename)
+        return None
+
+    username, password = parts[0].strip(), parts[1].strip()
+    if not username or not password:
+        log.error('Username or password is empty in credentials file: %s' % filename)
+        return None
+
+    return username, password
 
 
 def basic(filename):
     """
-    Get authorization using username and password contained in filename.
+    Get HTTP Basic authorization using username and password contained in filename.
+
+    Returns
+    -------
+    auth : HTTPBasicAuth or None
+        Authorization object, or None if credentials could not be read.
     """
     credentials = read_credentials(filename)
+    if credentials is None:
+        return None
 
-    username          = credentials[0][0]
-    password          = credentials[0][1]
-    auth = HTTPBasicAuth(username, password)
-
-    return auth
+    username, password = credentials
+    return HTTPBasicAuth(username, password)
 
 

--- a/dmagic/config.py
+++ b/dmagic/config.py
@@ -35,13 +35,13 @@ SECTIONS['general'] = {
 
 SECTIONS['settings'] = {
     'beamline' : {
-        'default' : '7-BM-B',
+        'default' : '2-BM-A,B',
         'type': str,
         'help': "beamline name as defined at https://www.aps.anl.gov/Beamlines/Directory, e.g. 2-BM-A,B or 7-BM-B or 32-ID-B,C"},
     'tomoscan-prefix':{
-        'default': '7bmb1:',
+        'default': '2bmb:TomoScan:',
         'type': str,
-        'help': "The tomoscan prefix, i.e.'7bmb1:' or '2bma:TomoScan:' "},
+        'help': "The tomoscan prefix, i.e. '2bmb:TomoScan:' "},
     'set': {
         'type': float,
         'default': 0,
@@ -60,27 +60,27 @@ SECTIONS['settings'] = {
 SECTIONS['dm'] = {
     'experiment-type': {
         'type': str,
-        'default': '7BM',
+        'default': '2BM',
         'help': 'Experiment type in the DM system'},
     'primary-beamline-contact-badge': {
         'type': int,
-        'default': 56788,
+        'default': 218262,
         'help': 'Badge number of primary beamline contact. Added to all DM experiments'},
     'primary-beamline-contact-email': {
         'type': str,
-        'default': 'user@anl.gov',
+        'default': 'pshevchenko@anl.gov',
         'help': 'Email address of primary beamline contact'},
     'secondary-beamline-contact-badge': {
         'type': int,
-        'default': 56788,
+        'default': 49734,
         'help': 'Badge number of secondary beamline contact. Added to all DM experiments'},
     'secondary-beamline-contact-email': {
         'type': str,
-        'default': 'user@anl.gov',
+        'default': 'decarlo@anl.gov',
         'help': 'Email address of secondary beamline contact'},
     'globus-message-file': {
         'type': str,
-        'default': 'message-7bm.txt',
+        'default': 'message-2bm.txt',
         'help': 'File name of the notification e-mail message template sent to users'},
     'globus-server-uuid': {
         'type': str,
@@ -88,7 +88,7 @@ SECTIONS['dm'] = {
         'help': 'UUID of the Globus endpoint for the data management server (Sojourner)'},
     'globus-server-top-dir': {
         'type': str,
-        'default': '/gdata/dm/7BM',
+        'default': '/gdata/dm/2BM',
         'help': 'Path from data storage root to the beamline top directory'},
     'manual': {
         'default': False,

--- a/dmagic/config.py
+++ b/dmagic/config.py
@@ -92,48 +92,45 @@ SECTIONS['site'] = {
         'action': 'store_true'},
     }
 
-SECTIONS['create'] = {
+SECTIONS['manual'] = {
     'badges': {
         'type': str,
         'default': '',
-        'help': 'Comma-separated badge numbers for a manual experiment'},
+        'help': 'Comma-separated badge numbers to add to the experiment'},
     'date': {
         'type': str,
         'default': '',
-        'help': 'Year-month for manual experiment in yyyy-mm format (default: current month)'},
+        'help': 'Year-month in yyyy-mm format (default: current month)'},
     'email': {
         'type': str,
         'default': '',
-        'help': 'PI email for manual experiment'},
+        'help': 'PI email address'},
     'first-name': {
         'type': str,
         'default': '',
-        'help': 'PI first name for manual experiment'},
+        'help': 'PI first name'},
     'institution': {
         'type': str,
         'default': '',
-        'help': 'PI institution for manual experiment'},
-    'manual': {
-        'default': False,
-        'help': 'Create a manual experiment (not from the scheduling system)',
-        'action': 'store_true'},
+        'help': 'PI institution'},
     'name': {
         'type': str,
         'default': 'Staff',
-        'help': 'PI last name for manual experiment'},
+        'help': 'PI last name'},
     'title': {
         'type': str,
         'default': 'Commissioning',
-        'help': 'Title for manual experiment'},
+        'help': 'Experiment title'},
     }
 
 INIT_PARAMS   = ('site',)
 SHOW_PARAMS   = ('settings',)
 TAG_PARAMS    = ('settings',)
-CREATE_PARAMS = ('settings', 'create')
+CREATE_PARAMS = ('settings',)
+MANUAL_PARAMS = ('manual',)
 EMAIL_PARAMS  = ()
 SITE_SUPPRESS = ('site',)
-NICE_NAMES    = ('General', 'Settings', 'Site', 'Create')
+NICE_NAMES    = ('General', 'Settings', 'Site', 'Manual')
 # Note: 'General' section only contains --config which is not logged
 
 

--- a/dmagic/config.py
+++ b/dmagic/config.py
@@ -126,11 +126,11 @@ SECTIONS['manual'] = {
 SECTIONS['local'] = {
     'analysis': {
         'type': str,
-        'default': 'localhost',
+        'default': 'tomodata3',
         'help': 'Hostname of the data analysis computer'},
     'analysis-top-dir': {
         'type': str,
-        'default': '/local/data/',
+        'default': '/data3/2BM/',
         'help': 'Top-level data directory on the analysis computer'},
     }
 

--- a/dmagic/config.py
+++ b/dmagic/config.py
@@ -42,7 +42,7 @@ SECTIONS['settings'] = {
         'default': '7bmb1:',
         'type': str,
         'help': "The tomoscan prefix, i.e.'7bmb1:' or '2bma:TomoScan:' "},
-    'set': {     
+    'set': {
         'type': float,
         'default': 0,
         'help': "Number of +/- number days for the current date. Used for setting user info for past/future user groups"},
@@ -54,12 +54,86 @@ SECTIONS['settings'] = {
         'default': CREDENTIALS_FILE_NAME,
         'type': str,
         'help': "File name containing the restAPI service credetinals in the format of user|pwd",
-        'metavar': 'FILE'},    
+        'metavar': 'FILE'},
     }
+
+SECTIONS['dm'] = {
+    'experiment-type': {
+        'type': str,
+        'default': '7BM',
+        'help': 'Experiment type in the DM system'},
+    'primary-beamline-contact-badge': {
+        'type': int,
+        'default': 56788,
+        'help': 'Badge number of primary beamline contact. Added to all DM experiments'},
+    'primary-beamline-contact-email': {
+        'type': str,
+        'default': 'user@anl.gov',
+        'help': 'Email address of primary beamline contact'},
+    'secondary-beamline-contact-badge': {
+        'type': int,
+        'default': 56788,
+        'help': 'Badge number of secondary beamline contact. Added to all DM experiments'},
+    'secondary-beamline-contact-email': {
+        'type': str,
+        'default': 'user@anl.gov',
+        'help': 'Email address of secondary beamline contact'},
+    'globus-message-file': {
+        'type': str,
+        'default': 'message-7bm.txt',
+        'help': 'File name of the notification e-mail message template sent to users'},
+    'globus-server-uuid': {
+        'type': str,
+        'default': '054a0877-97ca-4d80-947f-47ca522b173e',
+        'help': 'UUID of the Globus endpoint for the data management server (Sojourner)'},
+    'globus-server-top-dir': {
+        'type': str,
+        'default': '/gdata/dm/7BM',
+        'help': 'Path from data storage root to the beamline top directory'},
+    'manual': {
+        'default': False,
+        'help': 'Create a manual experiment (not from the scheduling system)',
+        'action': 'store_true'},
+    'badges': {
+        'type': str,
+        'default': '',
+        'help': 'Comma-separated list of badge numbers for a manual experiment'},
+    'date': {
+        'type': str,
+        'default': '',
+        'help': 'Year-month for manual experiment in yyyy-mm format (default: current month)'},
+    'name': {
+        'type': str,
+        'default': 'Staff',
+        'help': 'PI last name for manual experiment'},
+    'first-name': {
+        'type': str,
+        'default': '',
+        'help': 'PI first name for manual experiment'},
+    'institution': {
+        'type': str,
+        'default': '',
+        'help': 'PI institution for manual experiment'},
+    'email': {
+        'type': str,
+        'default': '',
+        'help': 'PI email for manual experiment'},
+    'title': {
+        'type': str,
+        'default': 'Commissioning',
+        'help': 'Title for manual experiment'},
+    }
+
+SECTIONS['email'] = {
+    'schedule': {
+        'default': False,
+        'help': 'Set to True to send an email to all users listed in the current proposal',
+        'action': 'store_true'}}
 
 
 DMAGIC_PARAMS = ('settings',)
-NICE_NAMES = ('General', 'Settings')
+DM_PARAMS = ('settings', 'dm', 'email')
+NICE_NAMES = ('General', 'Settings', 'DM', 'Email')
 
 def get_config_name():
     """Get the command line --config option."""

--- a/dmagic/config.py
+++ b/dmagic/config.py
@@ -124,16 +124,9 @@ SECTIONS['dm'] = {
         'help': 'Title for manual experiment'},
     }
 
-SECTIONS['email'] = {
-    'schedule': {
-        'default': False,
-        'help': 'Set to True to send an email to all users listed in the current proposal',
-        'action': 'store_true'}}
-
-
 DMAGIC_PARAMS = ('settings',)
-DM_PARAMS = ('settings', 'dm', 'email')
-NICE_NAMES = ('General', 'Settings', 'DM', 'Email')
+DM_PARAMS = ('settings', 'dm')
+NICE_NAMES = ('General', 'Settings', 'DM')
 
 def get_config_name():
     """Get the command line --config option."""

--- a/dmagic/config.py
+++ b/dmagic/config.py
@@ -123,14 +123,26 @@ SECTIONS['manual'] = {
         'help': 'Experiment title'},
     }
 
+SECTIONS['local'] = {
+    'analysis': {
+        'type': str,
+        'default': 'localhost',
+        'help': 'Hostname of the data analysis computer'},
+    'analysis-top-dir': {
+        'type': str,
+        'default': '/local/data/',
+        'help': 'Top-level data directory on the analysis computer'},
+    }
+
 INIT_PARAMS   = ('site',)
 SHOW_PARAMS   = ('settings',)
 TAG_PARAMS    = ('settings',)
 CREATE_PARAMS = ('settings',)
 MANUAL_PARAMS = ('manual',)
 EMAIL_PARAMS  = ()
+DAQ_PARAMS    = ('local',)
 SITE_SUPPRESS = ('site',)
-NICE_NAMES    = ('General', 'Settings', 'Site', 'Manual')
+NICE_NAMES    = ('General', 'Settings', 'Site', 'Manual', 'Local')
 # Note: 'General' section only contains --config which is not logged
 
 
@@ -160,7 +172,6 @@ def parse_known_args(parser, subparser=False):
         subparser_value = [sys.argv[1]] if subparser else []
         config_values = config_to_list(config_name=get_config_name())
         values = subparser_value + config_values + sys.argv[1:]
-        #print(subparser_value, config_values, values)
     else:
         values = ""
 

--- a/dmagic/config.py
+++ b/dmagic/config.py
@@ -26,11 +26,7 @@ SECTIONS['general'] = {
         'default': CONFIG_FILE_NAME,
         'type': str,
         'help': "File name of configuration",
-        'metavar': 'FILE'},
-    'verbose': {
-        'default': True,
-        'help': 'Verbose output',
-        'action': 'store_true'}}
+        'metavar': 'FILE'}}
 
 
 SECTIONS['settings'] = {
@@ -90,6 +86,10 @@ SECTIONS['site'] = {
         'default': 'https://beam-api.aps.anl.gov',
         'type': str,
         'help': "URL of the scheduling system REST API"},
+    'verbose': {
+        'default': True,
+        'help': 'Verbose output',
+        'action': 'store_true'},
     }
 
 SECTIONS['create'] = {
@@ -134,6 +134,7 @@ CREATE_PARAMS = ('settings', 'create')
 EMAIL_PARAMS  = ()
 SITE_SUPPRESS = ('site',)
 NICE_NAMES    = ('General', 'Settings', 'Site', 'Create')
+# Note: 'General' section only contains --config which is not logged
 
 
 def get_config_name():

--- a/dmagic/config.py
+++ b/dmagic/config.py
@@ -18,7 +18,7 @@ __all__ = ['config_to_list',
 
 CONFIG_FILE_NAME = os.path.join(str(pathlib.Path.home()), 'dmagic.conf')
 CREDENTIALS_FILE_NAME = os.path.join(str(pathlib.Path.home()), '.scheduling_credentials')
-    
+
 SECTIONS = OrderedDict()
 
 SECTIONS['general'] = {
@@ -34,38 +34,42 @@ SECTIONS['general'] = {
 
 
 SECTIONS['settings'] = {
-    'beamline' : {
-        'default' : '2-BM-A,B',
-        'type': str,
-        'help': "beamline name as defined at https://www.aps.anl.gov/Beamlines/Directory, e.g. 2-BM-A,B or 7-BM-B or 32-ID-B,C"},
-    'tomoscan-prefix':{
-        'default': '2bmb:TomoScan:',
-        'type': str,
-        'help': "The tomoscan prefix, i.e. '2bmb:TomoScan:' "},
     'set': {
         'type': float,
         'default': 0,
-        'help': "Number of +/- number days for the current date. Used for setting user info for past/future user groups"},
-    'url':{
-        'default': 'https://beam-api.aps.anl.gov',
+        'help': "Number of +/- days offset from today for past/future user groups"},
+    }
+
+SECTIONS['site'] = {
+    'beamline': {
+        'default': '2-BM-A,B',
         'type': str,
-        'help': "URL address of the scheduling system REST API' "},
+        'help': "Beamline name, e.g. 2-BM-A,B or 7-BM-B or 32-ID-B,C"},
     'credentials': {
         'default': CREDENTIALS_FILE_NAME,
         'type': str,
-        'help': "File name containing the restAPI service credetinals in the format of user|pwd",
+        'help': "File with scheduling REST API credentials in user|pwd format",
         'metavar': 'FILE'},
-    }
-
-SECTIONS['dm'] = {
     'experiment-type': {
         'type': str,
         'default': '2BM',
         'help': 'Experiment type in the DM system'},
+    'globus-message-file': {
+        'type': str,
+        'default': 'message-2bm.txt',
+        'help': 'Email message template file name sent to users'},
+    'globus-server-top-dir': {
+        'type': str,
+        'default': '/gdata/dm/2BM',
+        'help': 'Path from data storage root to the beamline top directory'},
+    'globus-server-uuid': {
+        'type': str,
+        'default': '054a0877-97ca-4d80-947f-47ca522b173e',
+        'help': 'UUID of the Globus endpoint for the data management server (Sojourner)'},
     'primary-beamline-contact-badge': {
         'type': int,
         'default': 218262,
-        'help': 'Badge number of primary beamline contact. Added to all DM experiments'},
+        'help': 'Badge number of primary beamline contact'},
     'primary-beamline-contact-email': {
         'type': str,
         'default': 'pshevchenko@anl.gov',
@@ -73,39 +77,34 @@ SECTIONS['dm'] = {
     'secondary-beamline-contact-badge': {
         'type': int,
         'default': 49734,
-        'help': 'Badge number of secondary beamline contact. Added to all DM experiments'},
+        'help': 'Badge number of secondary beamline contact'},
     'secondary-beamline-contact-email': {
         'type': str,
         'default': 'decarlo@anl.gov',
         'help': 'Email address of secondary beamline contact'},
-    'globus-message-file': {
+    'tomoscan-prefix': {
+        'default': '2bmb:TomoScan:',
         'type': str,
-        'default': 'message-2bm.txt',
-        'help': 'File name of the notification e-mail message template sent to users'},
-    'globus-server-uuid': {
+        'help': "TomoScan EPICS IOC prefix, e.g. '2bmb:TomoScan:'"},
+    'url': {
+        'default': 'https://beam-api.aps.anl.gov',
         'type': str,
-        'default': '054a0877-97ca-4d80-947f-47ca522b173e',
-        'help': 'UUID of the Globus endpoint for the data management server (Sojourner)'},
-    'globus-server-top-dir': {
-        'type': str,
-        'default': '/gdata/dm/2BM',
-        'help': 'Path from data storage root to the beamline top directory'},
-    'manual': {
-        'default': False,
-        'help': 'Create a manual experiment (not from the scheduling system)',
-        'action': 'store_true'},
+        'help': "URL of the scheduling system REST API"},
+    }
+
+SECTIONS['create'] = {
     'badges': {
         'type': str,
         'default': '',
-        'help': 'Comma-separated list of badge numbers for a manual experiment'},
+        'help': 'Comma-separated badge numbers for a manual experiment'},
     'date': {
         'type': str,
         'default': '',
         'help': 'Year-month for manual experiment in yyyy-mm format (default: current month)'},
-    'name': {
+    'email': {
         'type': str,
-        'default': 'Staff',
-        'help': 'PI last name for manual experiment'},
+        'default': '',
+        'help': 'PI email for manual experiment'},
     'first-name': {
         'type': str,
         'default': '',
@@ -114,19 +113,28 @@ SECTIONS['dm'] = {
         'type': str,
         'default': '',
         'help': 'PI institution for manual experiment'},
-    'email': {
+    'manual': {
+        'default': False,
+        'help': 'Create a manual experiment (not from the scheduling system)',
+        'action': 'store_true'},
+    'name': {
         'type': str,
-        'default': '',
-        'help': 'PI email for manual experiment'},
+        'default': 'Staff',
+        'help': 'PI last name for manual experiment'},
     'title': {
         'type': str,
         'default': 'Commissioning',
         'help': 'Title for manual experiment'},
     }
 
-DMAGIC_PARAMS = ('settings',)
-DM_PARAMS = ('settings', 'dm')
-NICE_NAMES = ('General', 'Settings', 'DM')
+INIT_PARAMS   = ('site',)
+SHOW_PARAMS   = ('settings',)
+TAG_PARAMS    = ('settings',)
+CREATE_PARAMS = ('settings', 'create')
+EMAIL_PARAMS  = ()
+SITE_SUPPRESS = ('site',)
+NICE_NAMES    = ('General', 'Settings', 'Site', 'Create')
+
 
 def get_config_name():
     """Get the command line --config option."""
@@ -195,13 +203,19 @@ def config_to_list(config_name=CONFIG_FILE_NAME):
 
 
 class Params(object):
-    def __init__(self, sections=()):
+    def __init__(self, sections=(), suppress_sections=()):
         self.sections = sections + ('general',)
+        self.suppress_sections = suppress_sections
 
     def add_parser_args(self, parser):
         for section in self.sections:
             for name in sorted(SECTIONS[section]):
                 opts = SECTIONS[section][name]
+                parser.add_argument('--{}'.format(name), **opts)
+        for section in self.suppress_sections:
+            for name in sorted(SECTIONS[section]):
+                opts = dict(SECTIONS[section][name])
+                opts['help'] = argparse.SUPPRESS
                 parser.add_argument('--{}'.format(name), **opts)
 
     def add_arguments(self, parser):
@@ -259,4 +273,3 @@ def log_values(args):
             for entry in entries:
                 value = args[entry] if args[entry] is not None else "-"
                 log.info("  {:<16} {}".format(entry, value))
-

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -186,6 +186,17 @@ def make_pretty_user_name(user_obj):
     return ' '.join(parts)
 
 
+def get_experiment(exp_name):
+    """Return the DM experiment object for exp_name, or None if not found."""
+    try:
+        return exp_api.getExperimentByName(exp_name)
+    except Exception as e:
+        if 'does not exist' in str(e):
+            return None
+        log.error('Could not query DM experiment %s: %s' % (exp_name, str(e)))
+        return None
+
+
 def delete_experiment(args):
     """Delete a DM experiment from Sojourner by name.
 

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -230,7 +230,7 @@ def delete_experiment(exp_name):
     """
     log.info('Deleting DM experiment: %s' % exp_name)
     try:
-        exp_api.deleteExperiment(exp_name)
+        exp_api.deleteExperimentByName(exp_name)
         log.info('   Experiment %s successfully deleted' % exp_name)
         return True
     except Exception as e:

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -163,6 +163,22 @@ def add_users(exp_obj, username_list):
             log.error('   Could not add user {:s}: {:s}'.format(uname, str(e)))
 
 
+def remove_users(exp_name, username_list):
+    """Remove a list of DM usernames from an experiment."""
+    for uname in username_list:
+        try:
+            user_obj = user_api.getUserByUsername(uname)
+        except Exception as e:
+            log.error('   Could not find user {:s}: {:s}'.format(uname, str(e)))
+            continue
+        try:
+            user_api.deleteUserExperimentRole(uname, 'User', exp_name)
+            log.info('   Removed user {:s} from the DM experiment'.format(
+                        make_pretty_user_name(user_obj)))
+        except Exception as e:
+            log.error('   Could not remove user {:s}: {:s}'.format(uname, str(e)))
+
+
 def list_users_this_dm_exp(args):
     """Return the list of DM usernames on the current experiment, or None if not found."""
     log.info('Listing the users on the DM experiment')

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -186,6 +186,22 @@ def make_pretty_user_name(user_obj):
     return ' '.join(parts)
 
 
+def delete_experiment(args):
+    """Delete a DM experiment from Sojourner by name.
+
+    Returns True on success, False on error.
+    """
+    exp_name = make_experiment_name(args)
+    log.info('Deleting DM experiment: %s' % exp_name)
+    try:
+        exp_api.deleteExperiment(exp_name)
+        log.info('   Experiment %s successfully deleted' % exp_name)
+        return True
+    except Exception as e:
+        log.error('   Could not delete experiment %s: %s' % (exp_name, str(e)))
+        return False
+
+
 def make_data_link(args):
     """Build the Globus file-manager URL for the experiment data directory."""
     exp_name = make_experiment_name(args)

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -101,7 +101,7 @@ def create_experiment(args):
 
     log.info('Creating new DM experiment: {0:s}/{1:s}'.format(args.year_month, exp_name))
 
-    if args.manual:
+    if getattr(args, 'manual', False):
         start_date = args.manual_start
         end_date   = args.manual_end
     else:

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -164,7 +164,7 @@ def add_users(exp_obj, username_list):
 def list_users_this_dm_exp(args):
     """Return the list of DM usernames on the current experiment, or None if not found."""
     log.info('Listing the users on the DM experiment')
-    exp_name = make_experiment_name(args)
+    exp_name = getattr(args, '_exp_name', None) or make_experiment_name(args)
     try:
         exp_obj = exp_api.getExperimentByName(exp_name)
     except Exception as e:
@@ -240,8 +240,9 @@ def delete_experiment(exp_name):
 
 def make_data_link(args):
     """Build the Globus file-manager URL for the experiment data directory."""
-    exp_name = make_experiment_name(args)
-    target_dir = '/{:s}/{:s}/'.format(args.year_month, exp_name)
+    exp_name   = getattr(args, '_exp_name',   None) or make_experiment_name(args)
+    year_month = getattr(args, '_year_month',  None) or args.year_month
+    target_dir = '/{:s}/{:s}/'.format(year_month, exp_name)
     link = ('https://app.globus.org/file-manager?origin_id='
             + args.globus_server_uuid
             + '&origin_path='

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -197,12 +197,37 @@ def get_experiment(exp_name):
         return None
 
 
-def delete_experiment(args):
+def list_experiments_by_station(station, years=2):
+    """Return DM experiment objects for the station from the last `years` calendar years.
+
+    Uses getExperimentsByStation(stationName=station). Sorted newest first.
+    Returns [] on error or no results.
+    """
+    try:
+        result = exp_api.getExperimentsByStation(stationName=station)
+        if not result:
+            return []
+        exps = list(result) if isinstance(result, list) else list(result.values())
+        cutoff_year = datetime.datetime.now().year - years + 1
+        filtered = []
+        for e in exps:
+            try:
+                year = int(e.get('rootPath', '0').split('-')[0])
+                if year >= cutoff_year:
+                    filtered.append(e)
+            except (ValueError, IndexError):
+                pass
+        return sorted(filtered, key=lambda e: e.get('rootPath', ''), reverse=True)
+    except Exception as e:
+        log.error('Could not list DM experiments for station %s: %s' % (station, str(e)))
+        return []
+
+
+def delete_experiment(exp_name):
     """Delete a DM experiment from Sojourner by name.
 
     Returns True on success, False on error.
     """
-    exp_name = make_experiment_name(args)
     log.info('Deleting DM experiment: %s' % exp_name)
     try:
         exp_api.deleteExperiment(exp_name)

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -1,0 +1,197 @@
+import datetime
+
+from dm import ExperimentDsApi, UserDsApi
+from dm.common.exceptions.objectAlreadyExists import ObjectAlreadyExists
+
+from dmagic import log
+from dmagic import authorize
+from dmagic import scheduling
+from dmagic import utils
+
+__author__ = "Alan L Kastengren, Francesco De Carlo"
+__copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
+__docformat__ = 'restructuredtext en'
+
+exp_api  = ExperimentDsApi()
+user_api = UserDsApi()
+oee      = ObjectAlreadyExists
+
+
+def make_experiment_name(args):
+    """Build the DM experiment name from proposal metadata.
+
+    Format: {year_month}-{pi_last_name}-{gup_number}
+    Example: 2025-03-Smith-123456
+    """
+    pi_last_name = utils.clean_entry(args.pi_last_name)
+    return '{:s}-{:s}-{:s}'.format(args.year_month, pi_last_name, str(args.gup_number))
+
+
+def make_dm_username_list(args):
+    """Make a list of DM usernames 'd+badge#' from the current proposal (GUP number).
+
+    Returns None if the beamtime cannot be found in the scheduling system.
+    """
+    log.info('Making a list of DM system usernames from target proposal')
+    auth = authorize.basic(args.credentials)
+    if auth is None:
+        return None
+    target_prop = scheduling.get_beamtime(str(args.gup_number), auth, args)
+    if target_prop is None:
+        return None
+    users = target_prop['beamtime']['proposal']['experimenters']
+    log.info('   Adding the primary beamline contact')
+    user_ids = {'d' + str(args.primary_beamline_contact_badge)}
+    log.info('   Adding the secondary beamline contact')
+    user_ids.add('d' + str(args.secondary_beamline_contact_badge))
+    for u in users:
+        log.info('   Adding user {0}, {1}, badge {2}'.format(
+                    u['lastName'], u['firstName'], u['badge']))
+        user_ids.add('d' + str(u['badge']))
+    return user_ids
+
+
+def make_username_list(args):
+    """Return the list of DM usernames currently on the experiment."""
+    log.info('Making a list of DM system usernames from current DM experiment')
+    exp_name = make_experiment_name(args)
+    try:
+        exp_obj = exp_api.getExperimentByName(exp_name)
+        return exp_obj.get('experimentUsernameList', [])
+    except Exception as e:
+        log.error('No such experiment in the DM system: {:s}'.format(exp_name))
+        log.error('   Error: %s' % str(e))
+        log.error('   Have you run "dmagic create" yet?')
+        return []
+
+
+def make_user_email_list(username_list):
+    """Convert a list of DM usernames ('d+badge#') to email addresses."""
+    email_list = []
+    for u in username_list:
+        try:
+            user_obj = user_api.getUserByUsername(u)
+            email_list.append(user_obj['email'])
+            log.info('   Added email {:s} for user {:s}'.format(email_list[-1], u))
+        except Exception as e:
+            log.warning('   Problem loading email for user {:s}: {:s}'.format(u, str(e)))
+    return email_list
+
+
+def create_experiment(args):
+    """Create a new DM experiment on Sojourner.
+
+    Returns the experiment object (new or pre-existing), or None on error.
+    """
+    exp_name = make_experiment_name(args)
+    log.info('Checking for existing DM experiment')
+    try:
+        old_exp = exp_api.getExperimentByName(exp_name)
+        log.warning('   Experiment already exists: %s' % old_exp['name'])
+        return old_exp
+    except Exception as e:
+        error_msg = str(e)
+        if 'does not exist' in error_msg:
+            log.info('   Experiment does not exist yet, will create it')
+        else:
+            log.error('   Could not query DM system: %s' % error_msg)
+            return None
+
+    log.info('Creating new DM experiment: {0:s}/{1:s}'.format(args.year_month, exp_name))
+
+    if args.manual:
+        start_date = args.manual_start
+        end_date   = args.manual_end
+    else:
+        auth = authorize.basic(args.credentials)
+        if auth is None:
+            return None
+        target_beamtime = scheduling.get_beamtime(args.gup_number, auth, args)
+        if target_beamtime is None:
+            log.error('  Could not find beamtime for GUP %s. '
+                      'For a commissioning run with no proposal use: '
+                      '"dmagic create --manual --name <LastName> '
+                      '--title <Title> --badges <badge1,badge2,...>"'
+                      % args.gup_number)
+            return None
+        start_datetime = datetime.datetime.strptime(
+                            utils.fix_iso(target_beamtime['startTime']),
+                            '%Y-%m-%dT%H:%M:%S%z')
+        end_datetime = datetime.datetime.strptime(
+                            utils.fix_iso(target_beamtime['endTime']),
+                            '%Y-%m-%dT%H:%M:%S%z')
+        start_date = start_datetime.strftime('%d-%b-%y')
+        end_date   = end_datetime.strftime('%d-%b-%y')
+
+    try:
+        new_exp = exp_api.addExperiment(exp_name,
+                            typeName    = args.experiment_type,
+                            description = args.gup_title,
+                            rootPath    = args.year_month,
+                            startDate   = start_date,
+                            endDate     = end_date)
+        log.info('   Experiment successfully created: %s' % new_exp['name'])
+        return new_exp
+    except oee:
+        log.warning('   Experiment already exists (caught on create). Retrieving: %s' % exp_name)
+        return exp_api.getExperimentByName(exp_name)
+    except Exception as e:
+        log.error('   Could not create DM experiment: %s' % str(e))
+        return None
+
+
+def add_users(exp_obj, username_list):
+    """Add a list of DM usernames to an experiment."""
+    existing_unames = exp_obj.get('experimentUsernameList', [])
+    for uname in username_list:
+        try:
+            user_obj = user_api.getUserByUsername(uname)
+        except Exception as e:
+            log.error('   Could not find user {:s}: {:s}'.format(uname, str(e)))
+            continue
+        if uname in existing_unames:
+            log.warning('   User {:s} is already on the experiment'.format(
+                        make_pretty_user_name(user_obj)))
+            continue
+        try:
+            user_api.addUserExperimentRole(uname, 'User', exp_obj['name'])
+            log.info('   Added user {:s} to the DM experiment'.format(
+                        make_pretty_user_name(user_obj)))
+        except Exception as e:
+            log.error('   Could not add user {:s}: {:s}'.format(uname, str(e)))
+
+
+def list_users_this_dm_exp(args):
+    """Return the list of DM usernames on the current experiment, or None if not found."""
+    log.info('Listing the users on the DM experiment')
+    exp_name = make_experiment_name(args)
+    try:
+        exp_obj = exp_api.getExperimentByName(exp_name)
+    except Exception as e:
+        log.error('   No appropriate DM experiment found: %s' % str(e))
+        return None
+    username_list = exp_obj.get('experimentUsernameList', [])
+    if not username_list:
+        log.info('   No users for this experiment')
+        return None
+    return username_list
+
+
+def make_pretty_user_name(user_obj):
+    """Format a DM user object as 'FirstName MiddleName LastName'."""
+    parts = []
+    for key in ('firstName', 'middleName', 'lastName'):
+        if key in user_obj and user_obj[key]:
+            parts.append(user_obj[key])
+    return ' '.join(parts)
+
+
+def make_data_link(args):
+    """Build the Globus file-manager URL for the experiment data directory."""
+    exp_name = make_experiment_name(args)
+    target_dir = '/{:s}/{:s}/'.format(args.year_month, exp_name)
+    link = ('https://app.globus.org/file-manager?origin_id='
+            + args.globus_server_uuid
+            + '&origin_path='
+            + target_dir.replace('/', '%2F'))
+    return link

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -1,6 +1,7 @@
 import datetime
+import os
 
-from dm import ExperimentDsApi, UserDsApi
+from dm import ExperimentDsApi, UserDsApi, ExperimentDaqApi
 from dm.common.exceptions.objectAlreadyExists import ObjectAlreadyExists
 
 from dmagic import log
@@ -14,6 +15,7 @@ __docformat__ = 'restructuredtext en'
 
 exp_api  = ExperimentDsApi()
 user_api = UserDsApi()
+daq_api  = ExperimentDaqApi()
 oee      = ObjectAlreadyExists
 
 
@@ -248,3 +250,65 @@ def make_data_link(args):
             + '&origin_path='
             + target_dir.replace('/', '%2F'))
     return link
+
+
+def start_daq(exp_name, analysis, analysis_top_dir):
+    """Start a DM DAQ for exp_name, watching analysis_top_dir/exp_name on the analysis machine.
+
+    The DM system will monitor the directory for incoming files and transfer them automatically.
+    Returns True on success, False on error.
+    """
+    analysis_dir = os.path.join(analysis_top_dir.rstrip('/'), exp_name)
+    dm_dir_name  = '@{:s}:{:s}'.format(analysis, analysis_dir)
+
+    log.info('Checking for already running DAQ for experiment %s' % exp_name)
+    try:
+        current_daqs = daq_api.listDaqs()
+    except Exception as e:
+        log.error('   Could not list DAQs: %s' % str(e))
+        return False
+
+    for d in current_daqs:
+        if (d['experimentName'] == exp_name and d['status'] == 'running'
+                and d['dataDirectory'] == dm_dir_name):
+            log.warning('   DAQ is already running for %s. Returning.' % exp_name)
+            return True
+
+    log.info('Starting DAQ for experiment %s' % exp_name)
+    log.info('   Watching directory: %s' % dm_dir_name)
+    try:
+        daq_api.startDaq(exp_name, dm_dir_name)
+        log.info('   DAQ started successfully')
+        return True
+    except Exception as e:
+        log.error('   Could not start DAQ: %s' % str(e))
+        return False
+
+
+def stop_daq(exp_name):
+    """Stop all running DM DAQs for exp_name.
+
+    Returns True on success (including no DAQs found), False on error.
+    """
+    log.info('Stopping all DM DAQs for experiment %s' % exp_name)
+    try:
+        daqs = daq_api.listDaqs()
+    except Exception as e:
+        log.error('   Could not list DAQs: %s' % str(e))
+        return False
+
+    count = 0
+    for d in daqs:
+        if d['experimentName'] == exp_name and d['status'] == 'running':
+            log.info('   Found running DAQ. Stopping now.')
+            try:
+                daq_api.stopDaq(d['experimentName'], d['dataDirectory'])
+                count += 1
+            except Exception as e:
+                log.error('   Could not stop DAQ: %s' % str(e))
+
+    if count == 0:
+        log.info('   No active DAQs found for experiment %s' % exp_name)
+    else:
+        log.info('   Stopped %d DAQ(s) for experiment %s' % (count, exp_name))
+    return True

--- a/dmagic/message-2bm.txt
+++ b/dmagic/message-2bm.txt
@@ -1,0 +1,31 @@
+All,
+
+we are ready to start data collection, at the end of this message you will find the URL to access the raw and reconstructed data.
+We ask you to download and make a copy of the data (raw with a backup) within 4 weeks. After that time the data will be deleted from our systems, if you need more time please send an email to Francesco at decarlo@anl.gov or Pavel at pshevchenko@anl.gov
+
+To download data from the APS you need to create a globus account at https://www.globus.org/ using the very same email address listed here.
+Please read https://docs2bm.readthedocs.io/en/latest/source/manual/item_007.html
+for more information
+
+Data link:
+
+Below are other useful links:
+
+- beamline documentation and support request:
+https://docs2bm.readthedocs.io/
+
+- raw data viewers:
+fiji: https://imagej.net/Fiji and the hdf plugin from https://github.com/paulscherrerinstitute/ch.psi.imagej.hdf5
+hdfview https://support.hdfgroup.org/products/java/hdfview/
+argos (https://github.com/titusjan/argos)
+
+- reconstruction scripts find_center and recon are available at:
+https://github.com/tomography/tomopy-cli
+
+To run the reconstruction script you need to install tomopy:
+https://tomopy.readthedocs.io/
+
+If you have some interesting/challenging data set that you would like to share with the community submit a pull request at:
+https://tomobank.readthedocs.io
+
+The 2-BM Team

--- a/dmagic/message-7bm-nontomo.txt
+++ b/dmagic/message-7bm-nontomo.txt
@@ -1,0 +1,14 @@
+This is an automated message with important information about your experiment.  Your data will be automatically transferred to Sojourner, one of the main APS data storage systems.  The transfer will occur from the data analysis computer (mach), so any test reconstructions you do at the beamline should also be backed up to Sojourner.  Please note that this message was automatically sent to all users on the proposal.  If other users not on the proposal (for example, students or collaborators) should have this information, please forward it to them.
+
+Your data on Sojourner can be accessed through Globus Online, a grid FTP system.  Please go to the link below, or to https://www.globus.org and log in using your Globus credentials.  Sojourner is accessed through the aps#data endpoint.  Your credentials for Sojourner are your badge number prepended with a 'd' (for example, for badge number 123456, it would be d123456), with the same password as you use for the GUP and ESAF systems.  If you wish to have other APS users given access to these data (for example, students that were involved in an experiment who weren't on the original proposal), please let Alan know so he can add them as authorized users.
+
+Data link: 
+
+Please download and make a copy of the data (raw with a backup) within 4 weeks. After that time the data will be subject to deletion from our systems.  If you need more time please send an email to Alan at akastengren@anl.gov.
+
+For beamline documentation and support requests:
+https://docs7bm.readthedocs.io/
+
+Remember to send references to any papers written using data from APS to Alan at akastengren@anl.gov for inclusion in the APS Publications database.  Information on the database and the required acknowledgement statement for the use of APS can be found at https://www.aps.anl.gov/Science/Publications .
+=======
+The 7-BM Team

--- a/dmagic/message-7bm.txt
+++ b/dmagic/message-7bm.txt
@@ -1,0 +1,27 @@
+This is an automated message with important information about your experiment.  Your data will be automatically transferred to Sojourner, one of the main APS data storage systems.  The transfer will occur from the data analysis cluster, so any test reconstructions you do at the beamline should also be backed up to Voyager.  Please note that this message was automatically sent to all users on the proposal.  If other users not on the proposal (for example, students or collaborators) should have this information, please forward it to them.
+
+Your data on Sojourner can be accessed through Globus Online, a grid FTP system.  Please go to the link below, or to https://www.globus.org and log in using your Globus credentials.  Voyager is accessed through the APS:DM:7BM data endpoint.  Your credentials for Voyager are your badge number prepended with a 'd' (for example, for badge number 123456, it would be d123456), with the same password as you use for the GUP and ESAF systems.  If you wish to have other APS users given access to these data (for example, students that were involved in an experiment who weren't on the original proposal), please let Alan know so he can add them as authorized users.
+
+Data link: 
+
+Please download and make a copy of the data (raw with a backup) within 4 weeks. After that time the data will be subject to deletion from our systems.  If you need more time please send an email to Alan at akastengren@anl.gov or to Xiaoyang at lxiaoyang@anl.gov.
+
+Below are other useful links:
+
+- beamline documentation and support request:
+https://docs7bm.readthedocs.io/
+
+- raw data viewers:
+fiji: https://imagej.net/Fiji and the hdf plugin from https://github.com/paulscherrerinstitute/ch.psi.imagej.hdf5
+hdfview https://support.hdfgroup.org/products/java/hdfview/
+argos (https://github.com/titusjan/argos)
+
+To run the reconstruction script you need to install tomopy:
+https://tomocupy.readthedocs.io/en/latest/
+
+If you have some interesting/challenging data set that you would like to share with the community submit a pull request at:
+https://tomobank.readthedocs.io
+
+Remember to send references to any papers written using data from APS to Alan at akastengren@anl.gov and Xiaoyang and lxiaoyang@anl.gov for inclusion in the APS Publications database.  Information on the database and the required acknowledgement statement for the use of APS can be found at https://www.aps.anl.gov/Science/Publications .
+=======
+The 7-BM Team

--- a/dmagic/message.py
+++ b/dmagic/message.py
@@ -1,0 +1,88 @@
+import os
+import pathlib
+import smtplib
+
+from email.message import EmailMessage
+
+from dmagic import log
+from dmagic import dm
+
+
+def yes_or_no(question):
+    """Prompt the user for a Y/N answer. Returns True for yes, False for no."""
+    answer = str(input(question + " (Y/N): ")).lower().strip()
+    while answer not in ("y", "yes", "n", "no"):
+        log.warning("Input yes or no")
+        answer = str(input(question + " (Y/N): ")).lower().strip()
+    return answer[0] == "y"
+
+
+def _message_file_path(args):
+    """Resolve the email template file path relative to this module's directory."""
+    return os.path.join(pathlib.Path(__file__).parent, args.globus_message_file)
+
+
+def message(args):
+    """Read the email template, inject the current Globus data link, and return
+    an EmailMessage object ready to send.
+
+    The template file must contain a line starting with 'Data link:' which will
+    be replaced with the actual Globus URL for the experiment.
+    """
+    msg_file = _message_file_path(args)
+    with open(msg_file, 'r') as f:
+        lines = f.readlines()
+
+    data_link = dm.make_data_link(args)
+    with open(msg_file, 'w') as f:
+        for line in lines:
+            if line.startswith('Data link:'):
+                line = 'Data link: {:s}\n'.format(data_link)
+            f.write(line)
+
+    with open(msg_file, 'r') as f:
+        msg = EmailMessage()
+        msg.set_content(f.read())
+
+    msg['From']    = args.primary_beamline_contact_email
+    msg['Subject'] = 'Important information on APS experiment'
+    return msg
+
+
+def send_email(args):
+    """Send the experiment data-access email to all users on the DM experiment.
+
+    Prompts for confirmation before sending. SMTP sending is currently stubbed
+    out — uncomment the smtplib block below when ready to enable.
+    """
+    log.info("Send email to users?")
+    if not yes_or_no('   *** Yes or No'):
+        log.warning('   *** Message not sent')
+        return False
+
+    users = dm.list_users_this_dm_exp(args)
+    if users is None:
+        log.error('   Cannot send email: no DM experiment found. Have you run "dmagic create" yet?')
+        return False
+
+    emails = dm.make_user_email_list(users)
+    if not emails:
+        log.warning('   No user emails found on the DM experiment')
+
+    emails.append(args.primary_beamline_contact_email)
+    emails.append(args.secondary_beamline_contact_email)
+
+    log.info('   Would send email to: %s' % ', '.join(emails))
+
+    # Uncomment the block below to enable actual email sending:
+    # s = smtplib.SMTP('mailhost.anl.gov')
+    # for em in emails:
+    #     if args.msg['To'] is None:
+    #         args.msg['To'] = em
+    #     else:
+    #         args.msg.replace_header('To', em)
+    #     log.info('   Sending informational message to {:s}'.format(em))
+    #     s.send_message(args.msg)
+    # s.quit()
+
+    return True

--- a/dmagic/message.py
+++ b/dmagic/message.py
@@ -75,14 +75,14 @@ def send_email(args):
     log.info('   Would send email to: %s' % ', '.join(emails))
 
     # Uncomment the block below to enable actual email sending:
-    # s = smtplib.SMTP('mailhost.anl.gov')
-    # for em in emails:
-    #     if args.msg['To'] is None:
-    #         args.msg['To'] = em
-    #     else:
-    #         args.msg.replace_header('To', em)
-    #     log.info('   Sending informational message to {:s}'.format(em))
-    #     s.send_message(args.msg)
-    # s.quit()
+    s = smtplib.SMTP('mailhost.anl.gov')
+    for em in emails:
+        if args.msg['To'] is None:
+            args.msg['To'] = em
+        else:
+            args.msg.replace_header('To', em)
+        log.info('   Sending informational message to {:s}'.format(em))
+        s.send_message(args.msg)
+    s.quit()
 
     return True

--- a/dmagic/scheduling.py
+++ b/dmagic/scheduling.py
@@ -75,6 +75,8 @@ __copyright__ = "Copyright (c) 2015, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
 __all__ = ['current_run',
            'beamtime_requests',
+           'list_beamtimes',
+           'get_beamtime',
            'get_current_users',
            'get_current_pi',
            'get_current_proposal_id',
@@ -151,6 +153,117 @@ def beamtime_requests(run, auth, args):
         reply = requests.get(api_url, auth=auth)
 
         return reply.json()
+
+
+def list_beamtimes(auth, args):
+    """
+    List all beamtimes scheduled for the run containing today + args.set days.
+
+    Parameters
+    ----------
+    auth : HTTPBasicAuth
+        Basic http authorization.
+
+    Returns
+    -------
+    list of dict
+        Each dict contains: gup_number, gup_title, pi_last_name, pi_first_name,
+        pi_institution, pi_email, pi_badge, year_month, start_time, end_time, run_name.
+        Returns an empty list if none are found.
+    """
+    run = current_run(auth, args)
+    if run is None:
+        log.error("Could not determine run for the given --set offset")
+        return []
+
+    end_point = "beamline-scheduling/sched-api/activity/findByRunNameAndBeamlineId"
+    api_url = args.url + '/' + end_point + '/' + run + '/' + args.beamline
+    reply = requests.get(api_url, auth=auth)
+
+    if reply.status_code != 200:
+        log.error("No response from the restAPI. Error: %s" % reply.status_code)
+        return []
+
+    beamtimes = []
+    for item in reply.json():
+        proposal = item['beamtime']['proposal']
+        pi_last_name   = 'Unknown'
+        pi_first_name  = ''
+        pi_institution = ''
+        pi_email       = ''
+        pi_badge       = ''
+        for exp in proposal.get('experimenters', []):
+            if exp.get('piFlag') == 'Y':
+                pi_last_name   = exp.get('lastName', 'Unknown')
+                pi_first_name  = exp.get('firstName', '')
+                pi_institution = exp.get('institution', '')
+                pi_email       = str(exp.get('email', '')).lower()
+                pi_badge       = str(exp.get('badge', ''))
+                break
+
+        start_dt   = dt.datetime.fromisoformat(utils.fix_iso(item['startTime']))
+        year_month = start_dt.strftime('%Y-%m')
+
+        beamtimes.append({
+            'gup_number':     str(proposal['gupId']),
+            'gup_title':      proposal.get('proposalTitle', ''),
+            'pi_last_name':   pi_last_name,
+            'pi_first_name':  pi_first_name,
+            'pi_institution': pi_institution,
+            'pi_email':       pi_email,
+            'pi_badge':       pi_badge,
+            'year_month':     year_month,
+            'start_time':     item['startTime'],
+            'end_time':       item['endTime'],
+            'run_name':       run,
+        })
+
+    return beamtimes
+
+
+def get_beamtime(gup_number, auth, args):
+    """
+    Get the raw beamtime record for a specific GUP number in the current run.
+
+    Parameters
+    ----------
+    gup_number : str or int
+        The GUP number to look up.
+    auth : HTTPBasicAuth
+        Basic http authorization.
+
+    Returns
+    -------
+    dict or None
+        Raw beamtime item from the scheduling API, or None if not found.
+    """
+    run = current_run(auth, args)
+    if run is None:
+        log.error("Could not determine current run")
+        return None
+
+    end_point = "beamline-scheduling/sched-api/activity/findByRunNameAndBeamlineId"
+    api_url = args.url + '/' + end_point + '/' + run + '/' + args.beamline
+
+    if not str(gup_number).strip():
+        log.error("GUP number is empty")
+        return None
+
+    reply = requests.get(api_url, auth=auth)
+    if reply.status_code != 200:
+        log.error("No response from the restAPI. Error: %s" % reply.status_code)
+        return None
+
+    for item in reply.json():
+        gup_id = item['beamtime']['proposal'].get('gupId', '')
+        if not gup_id:
+            continue
+        if int(gup_id) == int(gup_number):
+            log.info("Beamtime for GUP %s found in run %s" % (gup_number, run))
+            return item
+
+    log.error("No beamtime from proposal %s found in run %s" % (gup_number, run))
+    return None
 
 
 def get_current_users(proposal):

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -40,7 +40,8 @@ the DM system monitors the experiment directory on the analysis machine (e.g.
 as data is collected. ``dmagic daq-stop`` stops the transfer at the end of the run.
 
 ``dmagic add-user`` adds one or more users to an existing experiment by badge number,
-prompting interactively if no badges are provided on the command line.
+and ``dmagic remove-user`` removes them, both prompting interactively if no badges are
+provided on the command line.
 
 ``dmagic email`` sends a data-access notification email to all users on the experiment,
 including the Globus URL to their data directory. Both proposal-based and manually created

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -39,6 +39,9 @@ the DM system monitors the experiment directory on the analysis machine (e.g.
 ``tomodata3:/data3/2BM/2026-03-Li-1012039``) and continuously transfers new files to Sojourner
 as data is collected. ``dmagic daq-stop`` stops the transfer at the end of the run.
 
+``dmagic add-user`` adds one or more users to an existing experiment by badge number,
+prompting interactively if no badges are provided on the command line.
+
 ``dmagic email`` sends a data-access notification email to all users on the experiment,
 including the Globus URL to their data directory. Both proposal-based and manually created
 experiments can be listed and removed using ``dmagic delete``.

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -3,17 +3,41 @@ About
 =====
 
 `DMagic <https://github.com/xray-imaging/DMagic>`_ provides a command-line interface to the
-`APS scheduling system <https://schedule.aps.anl.gov/>`_.
+`APS scheduling system <https://schedule.aps.anl.gov/>`_ and the APS Data Management (DM)
+system (`Sojourner <https://dm.aps.anl.gov/>`_).
 
-It bridges the APS scheduling system (which tracks who is running experiments and when) with
-the `EPICS <https://epics-controls.org/>`_ control system used to operate beamline equipment.
+Scheduling System Integration
+------------------------------
+
+DMagic bridges the APS scheduling system (which tracks who is running experiments and when)
+with the `EPICS <https://epics-controls.org/>`_ control system used to operate beamline
+equipment.
 
 For the current experiment, DMagic can retrieve PI and user information (name, affiliation,
 email, badge number) as well as proposal metadata (GUP ID, title, start/end times). This
-information can be printed to the terminal (``show`` command) or written directly into EPICS
-Process Variables on the beamline IOC (``tag`` command), ensuring that data files are
+information can be printed to the terminal (``dmagic show``) or written directly into EPICS
+Process Variables on the beamline IOC (``dmagic tag``), ensuring that data files are
 automatically attributed to the correct user group without manual entry.
 
+DM Experiment Management
+-------------------------
+
+DMagic also integrates with the APS Data Management system (Sojourner) to manage experiment
+records and user data access via `Globus <https://www.globus.org/>`_.
+
+For each beamtime, ``dmagic create`` registers a new experiment in Sojourner, creates the
+data directory structure on the beamline storage system, and grants Globus access to all
+users listed in the scheduling proposal. The experiment name follows the format
+``{YYYY-MM}-{PILastName}-{GUP#}`` (e.g. ``2026-03-Li-1012039``).
+
+For commissioning runs or staff experiments without a scheduling proposal, ``dmagic create-manual``
+creates a DM experiment using badge numbers and metadata provided directly on the command line
+(e.g. ``2026-03-Staff-0``).
+
+Once an experiment is created, ``dmagic email`` sends a data-access notification email to all
+users on the experiment, including the Globus URL to their data directory. Both proposal-based
+and manually created experiments can be listed and removed using ``dmagic delete``.
+
 DMagic is primarily used at tomography beamlines (e.g. 2-BM, 7-BM, 32-ID) in conjunction
-with `tomoScan <https://tomoscan.readthedocs.io/>`_ to populate user information PVs at the
-start of each user run.
+with `tomoScan <https://tomoscan.readthedocs.io/>`_ to populate user information PVs and
+manage data access at the start of each user run.

--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -34,9 +34,14 @@ For commissioning runs or staff experiments without a scheduling proposal, ``dma
 creates a DM experiment using badge numbers and metadata provided directly on the command line
 (e.g. ``2026-03-Staff-0``).
 
-Once an experiment is created, ``dmagic email`` sends a data-access notification email to all
-users on the experiment, including the Globus URL to their data directory. Both proposal-based
-and manually created experiments can be listed and removed using ``dmagic delete``.
+Once an experiment is created, ``dmagic daq-start`` starts automated real-time file transfer:
+the DM system monitors the experiment directory on the analysis machine (e.g.
+``tomodata3:/data3/2BM/2026-03-Li-1012039``) and continuously transfers new files to Sojourner
+as data is collected. ``dmagic daq-stop`` stops the transfer at the end of the run.
+
+``dmagic email`` sends a data-access notification email to all users on the experiment,
+including the Globus URL to their data directory. Both proposal-based and manually created
+experiments can be listed and removed using ``dmagic delete``.
 
 DMagic is primarily used at tomography beamlines (e.g. 2-BM, 7-BM, 32-ID) in conjunction
 with `tomoScan <https://tomoscan.readthedocs.io/>`_ to populate user information PVs and

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,6 +10,8 @@ for `DMagic <https://github.com/decarlof/DMagic>`_.
 
    api/dmagic.authorize
    api/dmagic.scheduling
+   api/dmagic.dm
+   api/dmagic.message
    api/dmagic.utils
 
 .. automodule:: dmagic

--- a/docs/source/api/dmagic.dm.rst
+++ b/docs/source/api/dmagic.dm.rst
@@ -1,0 +1,21 @@
+:mod:`dmagic.dm`
+================
+
+.. automodule:: dmagic.dm
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+   .. rubric:: **Functions:**
+
+   .. autosummary::
+
+      make_experiment_name
+      create_experiment
+      make_dm_username_list
+      add_users
+      make_username_list
+      make_user_email_list
+      list_users_this_dm_exp
+      make_pretty_user_name
+      make_data_link

--- a/docs/source/api/dmagic.message.rst
+++ b/docs/source/api/dmagic.message.rst
@@ -1,0 +1,15 @@
+:mod:`dmagic.message`
+=====================
+
+.. automodule:: dmagic.message
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
+   .. rubric:: **Functions:**
+
+   .. autosummary::
+
+      message
+      send_email
+      yes_or_no

--- a/docs/source/api/dmagic.scheduling.rst
+++ b/docs/source/api/dmagic.scheduling.rst
@@ -9,13 +9,15 @@
    .. rubric:: **Functions:**
 
    .. autosummary::
-   
-      beamtime_requests
+
       current_run
-      get_current_emails
-      get_current_pi
+      beamtime_requests
+      list_beamtimes
+      get_beamtime
       get_current_proposal
+      get_current_pi
+      get_current_users
+      get_current_emails
       get_current_proposal_id
       get_current_proposal_title
-      get_current_users
       get_proposal_starting_date

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -40,9 +40,13 @@ beamline before using any other commands::
     name = Staff
     title = Commissioning
 
+    [local]
+    analysis = tomodata3
+    analysis-top-dir = /data3/2BM/
+
 .. note::
-    The ``[site]`` section only needs to be configured once per beamline installation.
-    The ``[manual]`` section provides defaults for ``dmagic create-manual``.
+    The ``[site]`` and ``[local]`` sections only need to be configured once per beamline
+    installation. The ``[manual]`` section provides defaults for ``dmagic create-manual``.
 
 Scheduling System Commands
 ==========================
@@ -99,10 +103,13 @@ The information will be updated in the medm screen:
 DM Experiment Management
 =========================
 
-The ``create``, ``create-manual``, ``delete``, and ``email`` commands integrate with
-the APS Data Management (DM) system (Sojourner) to manage experiment records and user
-data access via Globus. These commands require the ``[site]`` section of ``~/dmagic.conf``
-to be correctly configured (see `Initialization`_ above).
+The ``create``, ``create-manual``, ``delete``, ``email``, ``daq-start``, and ``daq-stop``
+commands integrate with the APS Data Management (DM) system (Sojourner) to manage
+experiment records, user data access via Globus, and automated file transfer. These
+commands require the ``[site]`` section of ``~/dmagic.conf`` to be correctly configured
+(see `Initialization`_ above). The ``daq-start`` and ``daq-stop`` commands additionally
+require the ``[local]`` section to be configured with the correct analysis hostname and
+data directory.
 
 dmagic create
 -------------
@@ -264,6 +271,78 @@ experiment. Lists all station experiments and prompts for selection. Requires th
       -h, --help     show this help message and exit
       --config FILE  File name of configuration (default: /home/beams/2BMB/dmagic.conf)
 
+dmagic daq-start
+----------------
+
+Starts automated real-time file transfer (DAQ) to Sojourner. The DM system monitors
+the configured directory on the analysis machine for new files and transfers them
+continuously. Lists all station experiments and prompts for selection::
+
+    (dm) $ dmagic daq-start
+    2026-03-04 09:10:00,000 - Found 11 DM experiment(s) for station 2BM:
+      [ 0] 2026-03-Li-1018528                   2026-03-11 to 2026-03-14  Investigation of ...
+      [ 1] 2026-03-Li-1012039                   2026-03-03 to 2026-03-05  Investigation of ...
+      ...
+
+    Select experiment to start DAQ for [0-10] or 'q' to quit: 1
+    2026-03-04 09:10:05,000 - Checking for already running DAQ for experiment 2026-03-Li-1012039
+    2026-03-04 09:10:05,100 - Starting DAQ for experiment 2026-03-Li-1012039
+    2026-03-04 09:10:05,101 -    Watching directory: @tomodata3:/data3/2BM/2026-03-Li-1012039
+    2026-03-04 09:10:06,000 -    DAQ started successfully
+
+The ``analysis`` and ``analysis-top-dir`` settings in ``~/dmagic.conf`` control which
+host and directory the DM agent monitors. The monitored path is
+``{analysis-top-dir}/{experiment-name}`` on the ``analysis`` host. For best performance,
+point ``analysis`` at the storage node (e.g. ``tomodata3``) that physically hosts the
+data, rather than a compute node that accesses it via NFS.
+
+::
+
+    (dm) $ dmagic daq-start -h
+    usage: dmagic daq-start [-h] [--analysis ANALYSIS] [--analysis-top-dir ANALYSIS_TOP_DIR]
+                            [--config FILE]
+
+    Start automated real-time file transfer (DAQ) to Sojourner
+
+    options:
+      -h, --help            show this help message and exit
+      --analysis ANALYSIS   Hostname of the data analysis computer (default: tomodata3)
+      --analysis-top-dir ANALYSIS_TOP_DIR
+                            Top-level data directory on the analysis computer (default: /data3/2BM/)
+      --config FILE         File name of configuration (default: /home/beams/2BMB/dmagic.conf)
+
+dmagic daq-stop
+---------------
+
+Stops all running DAQs for the selected experiment. Lists all station experiments and
+prompts for selection::
+
+    (dm) $ dmagic daq-stop
+    2026-03-04 18:00:00,000 - Found 11 DM experiment(s) for station 2BM:
+      [ 0] 2026-03-Li-1018528                   2026-03-11 to 2026-03-14  Investigation of ...
+      [ 1] 2026-03-Li-1012039                   2026-03-03 to 2026-03-05  Investigation of ...
+      ...
+
+    Select experiment to stop DAQ for [0-10] or 'q' to quit: 1
+    2026-03-04 18:00:05,000 - Stopping all DM DAQs for experiment 2026-03-Li-1012039
+    2026-03-04 18:00:05,100 -    Found running DAQ. Stopping now.
+    2026-03-04 18:00:06,000 -    Stopped 1 DAQ(s) for experiment 2026-03-Li-1012039
+
+::
+
+    (dm) $ dmagic daq-stop -h
+    usage: dmagic daq-stop [-h] [--analysis ANALYSIS] [--analysis-top-dir ANALYSIS_TOP_DIR]
+                           [--config FILE]
+
+    Stop all running file transfers for the current experiment
+
+    options:
+      -h, --help            show this help message and exit
+      --analysis ANALYSIS   Hostname of the data analysis computer (default: tomodata3)
+      --analysis-top-dir ANALYSIS_TOP_DIR
+                            Top-level data directory on the analysis computer (default: /data3/2BM/)
+      --config FILE         File name of configuration (default: /home/beams/2BMB/dmagic.conf)
+
 Command Reference
 =================
 
@@ -286,3 +365,5 @@ Command Reference
                      Create a DM experiment manually for commissioning runs
         delete       Delete a DM experiment from Sojourner
         email        Send data-access email with Globus link to all users on the DM experiment
+        daq-start    Start automated real-time file transfer (DAQ) to Sojourner
+        daq-stop     Stop all running file transfers for the current experiment

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -255,11 +255,6 @@ experiment. Lists all station experiments and prompts for selection. Requires th
        *** Yes or No (Y/N): Y
     2026-03-04 09:05:06,000 -    Would send email to: user1@university.edu, ..., pshevchenko@anl.gov
 
-.. note::
-    SMTP sending via ``mailhost.anl.gov`` is available on ANL network machines but is
-    currently disabled by default. To enable it, uncomment the ``smtplib`` block in
-    ``dmagic/message.py``.
-
 ::
 
     (dm) $ dmagic email -h

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -104,7 +104,7 @@ DM Experiment Management
 =========================
 
 The ``create``, ``create-manual``, ``delete``, ``email``, ``daq-start``, ``daq-stop``,
-and ``add-user`` commands integrate with the APS Data Management (DM) system (Sojourner)
+``add-user``, and ``remove-user`` commands integrate with the APS Data Management (DM) system (Sojourner)
 to manage experiment records, user data access via Globus, and automated file transfer. These
 commands require the ``[site]`` section of ``~/dmagic.conf`` to be correctly configured
 (see `Initialization`_ above). The ``daq-start`` and ``daq-stop`` commands additionally
@@ -375,6 +375,45 @@ Badge numbers can also be passed directly on the command line::
       --config FILE    File name of configuration (default: /home/beams/2BMB/dmagic.conf)
       --badges BADGES  Comma-separated badge number(s) to add to the experiment (e.g. 12345 or 12345,67890) (default: )
 
+dmagic remove-user
+------------------
+
+Removes one or more users from an existing DM experiment by badge number. Lists all
+station experiments and prompts for selection, then shows the current user list before
+prompting for badge number(s) to remove::
+
+    (dm) $ dmagic remove-user
+    2026-03-06 09:00:00,000 - Found 10 DM experiment(s) for station 2BM:
+      [ 0] 2026-03-Li-1018528                   2026-03-11 to 2026-03-14  Investigation of ...
+      [ 1] 2026-03-Socha-1019623                2026-03-07 to 2026-03-09  Biomechanical ...
+      [ 2] 2026-03-Li-1012039                   2026-03-03 to 2026-03-05  Investigation of ...
+      ...
+
+    Select experiment to remove users from [0-9] or 'q' to quit: 2
+    2026-03-06 09:00:05,000 - Current users on 2026-03-Li-1012039:
+    2026-03-06 09:00:05,001 -    d12345
+    2026-03-06 09:00:05,002 -    d49734
+    2026-03-06 09:00:05,003 -    d218262
+    Enter badge number(s) to remove (comma-separated): 12345
+    2026-03-06 09:00:10,000 -    Removed user Jane Smith from the DM experiment
+
+Badge numbers can also be passed directly on the command line::
+
+    (dm) $ dmagic remove-user --badges 12345
+
+::
+
+    (dm) $ dmagic remove-user -h
+    usage: dmagic remove-user [-h] [--set SET] [--config FILE] [--badges BADGES]
+
+    Remove users from an existing DM experiment by badge number
+
+    options:
+      -h, --help       show this help message and exit
+      --set SET        Number of +/- days offset from today for past/future user groups (default: 0)
+      --config FILE    File name of configuration (default: /home/beams/2BMB/dmagic.conf)
+      --badges BADGES  Comma-separated badge number(s) to add/remove (e.g. 12345 or 12345,67890) (default: )
+
 Command Reference
 =================
 
@@ -400,3 +439,4 @@ Command Reference
         daq-start    Start automated real-time file transfer (DAQ) to Sojourner
         daq-stop     Stop all running file transfers for the current experiment
         add-user     Add users to an existing DM experiment by badge number
+        remove-user  Remove users from an existing DM experiment by badge number

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -103,9 +103,9 @@ The information will be updated in the medm screen:
 DM Experiment Management
 =========================
 
-The ``create``, ``create-manual``, ``delete``, ``email``, ``daq-start``, and ``daq-stop``
-commands integrate with the APS Data Management (DM) system (Sojourner) to manage
-experiment records, user data access via Globus, and automated file transfer. These
+The ``create``, ``create-manual``, ``delete``, ``email``, ``daq-start``, ``daq-stop``,
+and ``add-user`` commands integrate with the APS Data Management (DM) system (Sojourner)
+to manage experiment records, user data access via Globus, and automated file transfer. These
 commands require the ``[site]`` section of ``~/dmagic.conf`` to be correctly configured
 (see `Initialization`_ above). The ``daq-start`` and ``daq-stop`` commands additionally
 require the ``[local]`` section to be configured with the correct analysis hostname and
@@ -338,6 +338,42 @@ prompts for selection::
                             Top-level data directory on the analysis computer (default: /data3/2BM/)
       --config FILE         File name of configuration (default: /home/beams/2BMB/dmagic.conf)
 
+dmagic add-user
+---------------
+
+Adds one or more users to an existing DM experiment by badge number. Lists all station
+experiments and prompts for selection, then prompts for badge number(s) if not provided
+on the command line::
+
+    (dm) $ dmagic add-user
+    2026-03-05 14:32:00,000 - Found 10 DM experiment(s) for station 2BM:
+      [ 0] 2026-03-Li-1018528                   2026-03-11 to 2026-03-14  Investigation of ...
+      [ 1] 2026-03-Socha-1019623                2026-03-07 to 2026-03-09  Biomechanical ...
+      [ 2] 2026-03-Li-1012039                   2026-03-03 to 2026-03-05  Investigation of ...
+      ...
+
+    Select experiment to add users to [0-9] or 'q' to quit: 2
+    Enter badge number(s) to add (comma-separated): 12345,67890
+    2026-03-05 14:32:10,000 -    Added user Jane Smith to the DM experiment
+    2026-03-05 14:32:10,100 -    Added user John Doe to the DM experiment
+
+Badge numbers can also be passed directly on the command line::
+
+    (dm) $ dmagic add-user --badges 12345,67890
+
+::
+
+    (dm) $ dmagic add-user -h
+    usage: dmagic add-user [-h] [--set SET] [--config FILE] [--badges BADGES]
+
+    Add users to an existing DM experiment by badge number
+
+    options:
+      -h, --help       show this help message and exit
+      --set SET        Number of +/- days offset from today for past/future user groups (default: 0)
+      --config FILE    File name of configuration (default: /home/beams/2BMB/dmagic.conf)
+      --badges BADGES  Comma-separated badge number(s) to add to the experiment (e.g. 12345 or 12345,67890) (default: )
+
 Command Reference
 =================
 
@@ -362,3 +398,4 @@ Command Reference
         email        Send data-access email with Globus link to all users on the DM experiment
         daq-start    Start automated real-time file transfer (DAQ) to Sojourner
         daq-stop     Stop all running file transfers for the current experiment
+        add-user     Add users to an existing DM experiment by badge number

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -80,6 +80,68 @@ The information associated with the current user/experiment will be updated in t
   :width: 400
   :alt: medm screen
 
+DM Experiment Management
+=========================
+
+The ``create`` and ``email`` commands integrate with the APS Data Management (DM) system
+(Sojourner) to manage experiment records and user data access via Globus.
+
+Before using these commands, configure the ``[dm]`` section of ``~/dmagic.conf`` with
+your beamline-specific values::
+
+    [dm]
+    experiment-type = 7BM
+    primary-beamline-contact-badge = 12345
+    primary-beamline-contact-email = scientist@anl.gov
+    secondary-beamline-contact-badge = 12345
+    secondary-beamline-contact-email = scientist@anl.gov
+    globus-server-uuid = 054a0877-97ca-4d80-947f-47ca522b173e
+    globus-server-top-dir = /gdata/dm/7BM
+    globus-message-file = message-7bm.txt
+
+dmagic create
+-------------
+
+Creates a DM experiment on Sojourner for the current beamtime and adds all users from
+the scheduling proposal. Lists all beamtimes in the current run and prompts for selection::
+
+    (dm) $ dmagic create
+    2025-03-04 09:00:00,000 - Found 2 beamtimes in run 2025-1:
+      [0] GUP 12345 - PI: Smith - In-situ tomography of ...
+           2025-03-03T08:00:00-06:00 to 2025-03-05T08:00:00-06:00
+      [1] GUP 67890 - PI: Jones - High-speed imaging of ...
+           2025-03-05T08:00:00-06:00 to 2025-03-07T08:00:00-06:00
+
+    Select beamtime [0-1] or 'q' to quit: 0
+    2025-03-04 09:00:01,000 - Create summary:
+    2025-03-04 09:00:01,000 -    Experiment : 2025-03/2025-03-Smith-12345
+    2025-03-04 09:00:01,000 -    Title      : In-situ tomography of ...
+       *** Confirm? Yes or No (Y/N): Y
+    2025-03-04 09:00:03,000 -    Experiment successfully created: 2025-03-Smith-12345
+    2025-03-04 09:00:03,500 -    Added user John Smith to the DM experiment
+    2025-03-04 09:00:03,600 -    Added user Jane Doe to the DM experiment
+
+For commissioning runs or staff experiments with no scheduling proposal, use ``--manual``::
+
+    (dm) $ dmagic create --manual --name Staff --title Commissioning --badges 12345,67890
+
+dmagic email
+------------
+
+Sends a data-access notification email with a Globus link to all users on the DM
+experiment. Requires that ``dmagic create`` has been run first, and that a message
+template file (``globus-message-file`` in config) exists::
+
+    (dm) $ dmagic email
+    2025-03-04 09:05:00,000 - Sending e-mail to users on the DM experiment
+    Send email to users?
+       *** Yes or No (Y/N): Y
+    2025-03-04 09:05:01,000 -    Would send email to: smith@university.edu, doe@lab.gov, scientist@anl.gov
+
+.. note::
+    SMTP sending is currently disabled by default. To enable it, uncomment the
+    ``smtplib`` block in ``dmagic/message.py``.
+
 For help::
 
     (dm) $ dmagic -h
@@ -94,6 +156,8 @@ For help::
         init         Create configuration file
         show         Show user and experiment info from the APS schedule
         tag          Update user info EPICS PVs with info from the APS schedule
+        create       Create a DM experiment on Sojourner and add users from the scheduling system
+        email        Send data-access email with Globus link to all users on the DM experiment
 
 To access all options::
 
@@ -112,16 +176,22 @@ To access all options::
 
 ::
 
-    (dm) $ dmagic tag -h
-    usage: dmagic tag [-h] [--beamline BEAMLINE] [--set SET] [--tomoscan-prefix TOMOSCAN_PREFIX] [--url URL] [--config FILE] [--verbose]
+    (dm) $ dmagic create -h
+    usage: dmagic create [-h] [--beamline BEAMLINE] [--set SET] [--credentials FILE]
+                         [--url URL] [--experiment-type TYPE]
+                         [--primary-beamline-contact-badge N]
+                         [--primary-beamline-contact-email EMAIL]
+                         [--secondary-beamline-contact-badge N]
+                         [--secondary-beamline-contact-email EMAIL]
+                         [--globus-server-uuid UUID] [--globus-server-top-dir DIR]
+                         [--globus-message-file FILE]
+                         [--manual] [--badges BADGES] [--date DATE]
+                         [--name NAME] [--title TITLE] [--config FILE] [--verbose]
 
     optional arguments:
-      -h, --help            show this help message and exit
-      --beamline BEAMLINE   beamline name as defined at https://www.aps.anl.gov/Beamlines/Directory, e.g. 2-BM-A,B or 7-BM-B or 32-ID-B,C (default: 7-BM-B)
-      --set SET             Number of +/- number days for the current date. Used for setting user info for past/future user groups (default: 0)
-      --tomoscan-prefix TOMOSCAN_PREFIX
-                            The tomoscan prefix, i.e.'7bmb1:' or '2bma:TomoScan:' (default: 7bmb1:)
-      --url URL             URL address of the scheduling system REST API' (default: https://beam-api.aps.anl.gov)
-      --config FILE         File name of configuration (default: /Users/decarlo/dmagic.conf)
-      --verbose             Verbose output (default: True)
+      --manual              Create a manual experiment (not from the scheduling system)
+      --badges BADGES       Comma-separated list of badge numbers for a manual experiment
+      --date DATE           Year-month for manual experiment in yyyy-mm format
+      --name NAME           PI last name for manual experiment (default: Staff)
+      --title TITLE         Title for manual experiment (default: Commissioning)
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -2,79 +2,95 @@
 Usage
 =====
 
-DMagic retrieves user and experiment information from the APS scheduling system. To initialize DMagic status::
+DMagic retrieves user and experiment information from the APS scheduling system and
+integrates with the APS Data Management (DM) system (Sojourner) for experiment and
+user access management.
+
+Initialization
+==============
+
+To create the DMagic configuration file with default values::
 
     (dm) $ dmagic init
-    2024-03-29 20:18:31,165 - General
-    2024-03-29 20:18:31,165 -   config           /Users/decarlo/dmagic.conf
-    2024-03-29 20:18:31,165 -   verbose          True
 
-this creates the DMagic config file: ~/dmagic.conf with default values.
+This creates ``~/dmagic.conf``. Edit the ``[site]`` section to configure it for your
+beamline before using any other commands::
 
-To configure for your beamline and show the list of users that ran 1,500 days ago from today:
+    [general]
 
-::
+    [settings]
+    set = 0
 
-    (dm) $ dmagic show --beamline 2-BM-A,B --tomoscan-prefix  2bmb:TomoScan: --set -1500
-    2024-03-29 20:20:57,239 - Today's date: 2020-02-19 20:20:57.239632+00:00
-    2024-03-29 20:20:57,968 -   Run: 2020-1
-    2024-03-29 20:20:57,968 -   PI Name: Weinong Chen
-    2024-03-29 20:20:57,969 -   PI affiliation: Purdue University
-    2024-03-29 20:20:57,969 -   PI e-mail: wchen@purdue.edu
-    2024-03-29 20:20:57,969 -   PI badge: 226531
-    2024-03-29 20:20:57,969 -   Proposal GUP: 66310
-    2024-03-29 20:20:57,969 -   Proposal Title: In-situ visualization of pull-out behavior of z-pin reinforcement in sandwich panels using X-ray computed tomography
-    2024-03-29 20:20:57,969 -   Start date: 2020_02_17
-    2024-03-29 20:20:57,969 -   Start time: 2020-02-17 08:00:00-06:00
-    2024-03-29 20:20:57,969 -   End Time: 2020-02-19 08:00:00-06:00
-    2024-03-29 20:20:57,969 -   User email address:
-    2024-03-29 20:20:57,969 -        jonathan.drk@gmail.com
-    2024-03-29 20:20:57,969 -        cdkirk@sandia.gov
-    2024-03-29 20:20:57,969 -        gzherui@purdue.edu
-    2024-03-29 20:20:57,969 -        scpaulson42@gmail.com
-    2024-03-29 20:20:57,969 -        nkedir@purdue.edu
-    2024-03-29 20:20:57,969 -        wchen@purdue.edu
-    2024-03-29 20:20:57,969 -        aleenig@purdue.edu
-    2024-03-29 20:20:57,970 - General
-    2024-03-29 20:20:57,970 -   config           /Users/decarlo/dmagic.conf
-    2024-03-29 20:20:57,970 -   verbose          True
-    2024-03-29 20:20:57,970 - Settings
-    2024-03-29 20:20:57,970 -   beamline         2-BM-A,B
-    2024-03-29 20:20:57,970 -   set              -1500.0
-    2024-03-29 20:20:57,970 -   tomoscan_prefix  2bmb:TomoScan:
-    2024-03-29 20:20:57,970 -   url              https://beam-api.aps.anl.gov
+    [site]
+    beamline = 2-BM-A,B
+    credentials = /home/beams/2BMB/.scheduling_credentials
+    experiment-type = 2BM
+    globus-message-file = message-2bm.txt
+    globus-server-top-dir = /gdata/dm/2BM
+    globus-server-uuid = 054a0877-97ca-4d80-947f-47ca522b173e
+    primary-beamline-contact-badge = 218262
+    primary-beamline-contact-email = pshevchenko@anl.gov
+    secondary-beamline-contact-badge = 49734
+    secondary-beamline-contact-email = decarlo@anl.gov
+    tomoscan-prefix = 2bmb:TomoScan:
+    url = https://beam-api.aps.anl.gov
+    verbose = True
+
+    [manual]
+    name = Staff
+    title = Commissioning
 
 .. note::
-    You only need to pass ``--beamline 2-BM-A,B`` and  ``--tomoscan-prefix 2bmb:TomoScan:`` once,
-    then you can only run ``dmagic show``
+    The ``[site]`` section only needs to be configured once per beamline installation.
+    The ``[manual]`` section provides defaults for ``dmagic create-manual``.
 
+Scheduling System Commands
+==========================
 
-To update the EPICS PVs with data retrieved from the APS scheduling system run:
+dmagic show
+-----------
 
-::
+Queries the APS scheduling REST API to display the currently active experiment::
+
+    (dm) $ dmagic show
+    2026-03-04 09:00:00,000 - Today's date: 2026-03-04 09:00:00.000000+00:00
+    2026-03-04 09:00:00,700 -   Run: 2026-1
+    2026-03-04 09:00:00,701 -   PI Name: Weinong Chen
+    2026-03-04 09:00:00,702 -   PI affiliation: Purdue University
+    2026-03-04 09:00:00,703 -   PI e-mail: wchen@purdue.edu
+    2026-03-04 09:00:00,704 -   PI badge: 226531
+    2026-03-04 09:00:00,705 -   Proposal GUP: 66310
+    2026-03-04 09:00:00,706 -   Proposal Title: In-situ visualization of ...
+    2026-03-04 09:00:00,707 -   Start date: 2026_03_03
+    2026-03-04 09:00:00,708 -   Start time: 2026-03-03 08:00:00-06:00
+    2026-03-04 09:00:00,709 -   End Time: 2026-03-05 08:00:00-06:00
+    2026-03-04 09:00:00,710 -   User email address:
+    2026-03-04 09:00:00,711 -        user1@university.edu
+    2026-03-04 09:00:00,712 -        user2@lab.gov
+
+Use ``--set N`` to offset the date (negative for past, positive for future)::
+
+    (dm) $ dmagic show --set -1500
+
+dmagic tag
+----------
+
+Fetches the same scheduling data and writes it to EPICS PVs on the TomoScan IOC::
 
     (dm) $ dmagic tag
-    2024-03-29 20:29:02,028 - Today's date: 2024-03-29 20:29:02.028035
-    2024-03-29 20:29:02,700 - User/Experiment PV update
-    2024-03-29 20:29:02,701 - Updating pi_name EPICS PV with: Weinong
-    2024-03-29 20:29:02,702 - Updating pi_last_name EPICS PV with: Chen
-    2024-03-29 20:29:02,703 - Updating pi_affiliation EPICS PV with: Purdue University
-    2024-03-29 20:29:02,704 - Updating pi_email EPICS PV with: wchen@purdue.edu
-    2024-03-29 20:29:02,705 - Updating pi_badge EPICS PV with: 226531
-    2024-03-29 20:29:02,706 - Updating user_info_update_time EPICS PV with: 2024-03-29T20:29:02.028035-05:00
-    2024-03-29 20:29:02,707 - Updating proposal_number EPICS PV with: 66310
-    2024-03-29 20:29:02,708 - Updating proposal_title EPICS PV with: In-situ visualization of pull-out behavior of z-pin reinforcement in sandwich panels using X-ray computed tomography
-    2024-03-29 20:29:02,709 - Updating experiment_date EPICS PV with: 2020-02
-    2024-03-29 20:29:02,710 - General
-    2024-03-29 20:29:02,710 -   config           /Users/decarlo/dmagic.conf
-    2024-03-29 20:29:02,710 -   verbose          True
-    2024-03-29 20:29:02,710 - Settings
-    2024-03-29 20:29:02,710 -   beamline         2-BM-A,B
-    2024-03-29 20:29:02,710 -   set              -1500.0
-    2024-03-29 20:29:02,710 -   tomoscan_prefix  2bmb:TomoScan:
-    2024-03-29 20:29:02,710 -   url              https://beam-api.aps.anl.gov
+    2026-03-04 09:00:00,000 - Today's date: 2026-03-04 09:00:00.000000
+    2026-03-04 09:00:01,000 - User/Experiment PV update
+    2026-03-04 09:00:01,001 - Updating pi_name EPICS PV with: Weinong
+    2026-03-04 09:00:01,002 - Updating pi_last_name EPICS PV with: Chen
+    2026-03-04 09:00:01,003 - Updating pi_affiliation EPICS PV with: Purdue University
+    2026-03-04 09:00:01,004 - Updating pi_email EPICS PV with: wchen@purdue.edu
+    2026-03-04 09:00:01,005 - Updating pi_badge EPICS PV with: 226531
+    2026-03-04 09:00:01,006 - Updating user_info_update_time EPICS PV with: 2026-03-04T09:00:01-06:00
+    2026-03-04 09:00:01,007 - Updating proposal_number EPICS PV with: 66310
+    2026-03-04 09:00:01,008 - Updating proposal_title EPICS PV with: In-situ visualization of ...
+    2026-03-04 09:00:01,009 - Updating experiment_date EPICS PV with: 2026-03
 
-The information associated with the current user/experiment will be updated in the medm screen:
+The information will be updated in the medm screen:
 
 .. image:: img/medm_screen.png
   :width: 400
@@ -83,71 +99,180 @@ The information associated with the current user/experiment will be updated in t
 DM Experiment Management
 =========================
 
-The ``create`` and ``email`` commands integrate with the APS Data Management (DM) system
-(Sojourner) to manage experiment records and user data access via Globus.
-
-Before using these commands, configure the ``[dm]`` section of ``~/dmagic.conf`` with
-your beamline-specific values::
-
-    [dm]
-    experiment-type = 7BM
-    primary-beamline-contact-badge = 12345
-    primary-beamline-contact-email = scientist@anl.gov
-    secondary-beamline-contact-badge = 12345
-    secondary-beamline-contact-email = scientist@anl.gov
-    globus-server-uuid = 054a0877-97ca-4d80-947f-47ca522b173e
-    globus-server-top-dir = /gdata/dm/7BM
-    globus-message-file = message-7bm.txt
+The ``create``, ``create-manual``, ``delete``, and ``email`` commands integrate with
+the APS Data Management (DM) system (Sojourner) to manage experiment records and user
+data access via Globus. These commands require the ``[site]`` section of ``~/dmagic.conf``
+to be correctly configured (see `Initialization`_ above).
 
 dmagic create
 -------------
 
-Creates a DM experiment on Sojourner for the current beamtime and adds all users from
-the scheduling proposal. Lists all beamtimes in the current run and prompts for selection::
+Creates a DM experiment on Sojourner for a proposal-based beamtime. Lists all beamtimes
+in the current APS run and prompts for selection, then creates the experiment and adds
+all users from the scheduling proposal::
 
     (dm) $ dmagic create
-    2025-03-04 09:00:00,000 - Found 2 beamtimes in run 2025-1:
-      [0] GUP 12345 - PI: Smith - In-situ tomography of ...
-           2025-03-03T08:00:00-06:00 to 2025-03-05T08:00:00-06:00
-      [1] GUP 67890 - PI: Jones - High-speed imaging of ...
-           2025-03-05T08:00:00-06:00 to 2025-03-07T08:00:00-06:00
+    2026-03-04 09:00:00,000 - Found 3 beamtimes in run 2026-1:
+      [ 0] GUP 1018528 - PI: Li - Investigation of multifunctional biomineralized ...
+           2026-03-11 to 2026-03-14
+      [ 1] GUP 1019623 - PI: Socha - Biomechanical constraints and trade-offs ...
+           2026-03-07 to 2026-03-09
+      [ 2] GUP 1012039 - PI: Li - Investigation of coupled mechanisms ...
+           2026-03-03 to 2026-03-05
 
-    Select beamtime [0-1] or 'q' to quit: 0
-    2025-03-04 09:00:01,000 - Create summary:
-    2025-03-04 09:00:01,000 -    Experiment : 2025-03/2025-03-Smith-12345
-    2025-03-04 09:00:01,000 -    Title      : In-situ tomography of ...
+    Select beamtime [0-2] or 'q' to quit: 2
+    2026-03-04 09:00:05,000 - Create summary:
+    2026-03-04 09:00:05,001 -    Experiment : 2026-03/2026-03-Li-1012039
+    2026-03-04 09:00:05,002 -    Title      : Investigation of coupled mechanisms ...
        *** Confirm? Yes or No (Y/N): Y
-    2025-03-04 09:00:03,000 -    Experiment successfully created: 2025-03-Smith-12345
-    2025-03-04 09:00:03,500 -    Added user John Smith to the DM experiment
-    2025-03-04 09:00:03,600 -    Added user Jane Doe to the DM experiment
+    2026-03-04 09:00:08,000 -    Experiment successfully created: 2026-03-Li-1012039
+    2026-03-04 09:00:08,500 -    Added user Tao Li to the DM experiment
+    2026-03-04 09:00:08,600 -    Added user Pavel Shevchenko to the DM experiment
+    ...
+    2026-03-04 09:00:09,000 - ============================================================
+    2026-03-04 09:00:09,001 - Experiment name : 2026-03-Li-1012039
+    2026-03-04 09:00:09,002 - Globus data link: https://app.globus.org/file-manager?...
+    2026-03-04 09:00:09,003 - ============================================================
 
-For commissioning runs or staff experiments with no scheduling proposal, use ``--manual``::
+::
 
-    (dm) $ dmagic create --manual --name Staff --title Commissioning --badges 12345,67890
+    (dm) $ dmagic create -h
+    usage: dmagic create [-h] [--set SET] [--config FILE]
+
+    Create a DM experiment from the APS scheduling system
+
+    options:
+      -h, --help     show this help message and exit
+      --set SET      Number of +/- days offset from today for past/future user groups (default: 0)
+      --config FILE  File name of configuration (default: /home/beams/2BMB/dmagic.conf)
+
+dmagic create-manual
+--------------------
+
+Creates a DM experiment manually for commissioning runs or staff experiments that have
+no scheduling proposal. Badge numbers, PI name, and title are provided on the command
+line::
+
+    (dm) $ dmagic create-manual --name DeCarlo --title "Vibration Tests" --badges 49734,218262
+
+::
+
+    (dm) $ dmagic create-manual -h
+    usage: dmagic create-manual [-h] [--badges BADGES] [--date DATE] [--email EMAIL]
+                                [--first-name FIRST_NAME] [--institution INSTITUTION]
+                                [--name NAME] [--title TITLE] [--config FILE]
+
+    Create a DM experiment manually for commissioning runs
+
+    options:
+      -h, --help            show this help message and exit
+      --badges BADGES       Comma-separated badge numbers to add to the experiment (default: )
+      --date DATE           Year-month in yyyy-mm format (default: current month) (default: )
+      --email EMAIL         PI email address (default: )
+      --first-name FIRST_NAME
+                            PI first name (default: )
+      --institution INSTITUTION
+                            PI institution (default: )
+      --name NAME           PI last name (default: Staff)
+      --title TITLE         Experiment title (default: Commissioning)
+      --config FILE         File name of configuration (default: /home/beams/2BMB/dmagic.conf)
+
+dmagic delete
+-------------
+
+Deletes a DM experiment from Sojourner. Lists all experiments for the configured station
+from the last 2 calendar years — this includes both proposal-based and manually created
+experiments. Requires double confirmation before deleting::
+
+    (dm) $ dmagic delete
+    2026-03-04 22:49:10,028 - Found 11 DM experiment(s) for station 2BM:
+      [ 0] 2026-03-Li-1018528                   2026-03-11 to 2026-03-14  Investigation of multifunctional biomineralized ...
+      [ 1] 2026-03-Socha-1019623                2026-03-07 to 2026-03-09  Biomechanical constraints and trade-offs ...
+      [ 2] 2026-03-Li-1012039                   2026-03-03 to 2026-03-05  Investigation of coupled mechanisms ...
+      [ 3] 2026-03-DeCarlo-0                    2026-03-01 to 2026-03-15  Vibration Tests
+      [ 4] 2026-03-Staff-0                      2026-03-04 to 2026-03-18  Commissioning
+      ...
+      [10] Nikitin-2025-06                      2025-06-23 to 2025-06-27  Viktor data from 2025-06
+
+    Select experiment to delete [0-10] or 'q' to quit: 4
+    2026-03-04 22:49:39,325 - ============================================================
+    2026-03-04 22:49:39,326 - *** PERMANENT DELETION — THIS CANNOT BE UNDONE ***
+    2026-03-04 22:49:39,327 -    Experiment     : 2026-03-Staff-0
+    2026-03-04 22:49:39,328 -    Storage dir    : /gdata/dm/2BM/2026-03/2026-03-Staff-0
+    2026-03-04 22:49:39,329 -    Data dir       : /gdata/dm/2BM/2026-03/2026-03-Staff-0/data
+    2026-03-04 22:49:39,330 -    Analysis dir   : /gdata/dm/2BM/2026-03/2026-03-Staff-0/analysis
+    2026-03-04 22:49:39,331 - ============================================================
+       *** Are you sure? Yes or No (Y/N): Y
+       *** Confirm AGAIN to permanently delete all data (Y/N): Y
+    2026-03-04 22:49:46,336 - Deleting DM experiment: 2026-03-Staff-0
+    2026-03-04 22:49:46,371 -    Experiment 2026-03-Staff-0 successfully deleted
+
+To delete a manually created experiment directly by name (without going through the list)::
+
+    (dm) $ dmagic delete --exp-name 2026-03-Staff-0
+
+::
+
+    (dm) $ dmagic delete -h
+    usage: dmagic delete [-h] [--set SET] [--config FILE] [--exp-name EXP_NAME]
+
+    Delete a DM experiment from Sojourner
+
+    options:
+      -h, --help           show this help message and exit
+      --set SET            Number of +/- days offset from today for past/future user groups (default: 0)
+      --config FILE        File name of configuration (default: /home/beams/2BMB/dmagic.conf)
+      --exp-name EXP_NAME  [Optional] Full DM experiment name, used only to delete commissioning
+                           experiments created with "dmagic create-manual" that are not in the
+                           APS scheduling system (e.g. 2026-03-Staff-0). Leave blank to select
+                           from the list of all station experiments. (default: None)
 
 dmagic email
 ------------
 
-Sends a data-access notification email with a Globus link to all users on the DM
-experiment. Requires that ``dmagic create`` has been run first, and that a message
-template file (``globus-message-file`` in config) exists::
+Sends a data-access notification email with a Globus link to all users on a DM
+experiment. Lists all station experiments and prompts for selection. Requires that
+``dmagic create`` or ``dmagic create-manual`` has been run first::
 
     (dm) $ dmagic email
-    2025-03-04 09:05:00,000 - Sending e-mail to users on the DM experiment
+    2026-03-04 09:05:00,000 - Found 11 DM experiment(s) for station 2BM:
+      [ 0] 2026-03-Li-1018528                   2026-03-11 to 2026-03-14  Investigation of ...
+      [ 1] 2026-03-Socha-1019623                2026-03-07 to 2026-03-09  Biomechanical ...
+      ...
+
+    Select experiment to email [0-10] or 'q' to quit: 0
+    2026-03-04 09:05:05,000 - Sending e-mail to users on the DM experiment: 2026-03-Li-1018528
+    2026-03-04 09:05:05,100 -    Message to users:
+    2026-03-04 09:05:05,200 -    *** All, ...
     Send email to users?
        *** Yes or No (Y/N): Y
-    2025-03-04 09:05:01,000 -    Would send email to: smith@university.edu, doe@lab.gov, scientist@anl.gov
+    2026-03-04 09:05:06,000 -    Would send email to: user1@university.edu, ..., pshevchenko@anl.gov
 
 .. note::
-    SMTP sending is currently disabled by default. To enable it, uncomment the
-    ``smtplib`` block in ``dmagic/message.py``.
+    SMTP sending via ``mailhost.anl.gov`` is available on ANL network machines but is
+    currently disabled by default. To enable it, uncomment the ``smtplib`` block in
+    ``dmagic/message.py``.
 
-For help::
+::
+
+    (dm) $ dmagic email -h
+    usage: dmagic email [-h] [--config FILE]
+
+    Send data-access email with Globus link to all users on the DM experiment
+
+    options:
+      -h, --help     show this help message and exit
+      --config FILE  File name of configuration (default: /home/beams/2BMB/dmagic.conf)
+
+Command Reference
+=================
+
+::
 
     (dm) $ dmagic -h
     usage: dmagic [-h] [--config FILE]  ...
 
-    optional arguments:
+    options:
       -h, --help     show this help message and exit
       --config FILE  File name of configuration
 
@@ -156,42 +281,8 @@ For help::
         init         Create configuration file
         show         Show user and experiment info from the APS schedule
         tag          Update user info EPICS PVs with info from the APS schedule
-        create       Create a DM experiment on Sojourner and add users from the scheduling system
+        create       Create a DM experiment from the APS scheduling system
+        create-manual
+                     Create a DM experiment manually for commissioning runs
+        delete       Delete a DM experiment from Sojourner
         email        Send data-access email with Globus link to all users on the DM experiment
-
-To access all options::
-
-    (dm) $ dmagic show -h
-    usage: dmagic show [-h] [--beamline BEAMLINE] [--set SET] [--tomoscan-prefix TOMOSCAN_PREFIX] [--url URL] [--config FILE] [--verbose]
-
-    optional arguments:
-      -h, --help            show this help message and exit
-      --beamline BEAMLINE   beamline name as defined at https://www.aps.anl.gov/Beamlines/Directory, e.g. 2-BM-A,B or 7-BM-B or 32-ID-B,C (default: 7-BM-B)
-      --set SET             Number of +/- number days for the current date. Used for setting user info for past/future user groups (default: 0)
-      --tomoscan-prefix TOMOSCAN_PREFIX
-                            The tomoscan prefix, i.e.'7bmb1:' or '2bma:TomoScan:' (default: 7bmb1:)
-      --url URL             URL address of the scheduling system REST API' (default: https://beam-api.aps.anl.gov)
-      --config FILE         File name of configuration (default: /Users/decarlo/dmagic.conf)
-      --verbose             Verbose output (default: True)
-
-::
-
-    (dm) $ dmagic create -h
-    usage: dmagic create [-h] [--beamline BEAMLINE] [--set SET] [--credentials FILE]
-                         [--url URL] [--experiment-type TYPE]
-                         [--primary-beamline-contact-badge N]
-                         [--primary-beamline-contact-email EMAIL]
-                         [--secondary-beamline-contact-badge N]
-                         [--secondary-beamline-contact-email EMAIL]
-                         [--globus-server-uuid UUID] [--globus-server-top-dir DIR]
-                         [--globus-message-file FILE]
-                         [--manual] [--badges BADGES] [--date DATE]
-                         [--name NAME] [--title TITLE] [--config FILE] [--verbose]
-
-    optional arguments:
-      --manual              Create a manual experiment (not from the scheduling system)
-      --badges BADGES       Comma-separated list of badge numbers for a manual experiment
-      --date DATE           Year-month for manual experiment in yyyy-mm format
-      --name NAME           PI last name for manual experiment (default: Staff)
-      --title TITLE         Title for manual experiment (default: Commissioning)
-

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -253,7 +253,8 @@ experiment. Lists all station experiments and prompts for selection. Requires th
     2026-03-04 09:05:05,200 -    *** All, ...
     Send email to users?
        *** Yes or No (Y/N): Y
-    2026-03-04 09:05:06,000 -    Would send email to: user1@university.edu, ..., pshevchenko@anl.gov
+    2026-03-04 09:05:06,000 -    Sending informational message to user1@university.edu
+    2026-03-04 09:05:06,100 -    Sending informational message to pshevchenko@anl.gov
 
 ::
 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     author_email = 'decarlo@anl.gov',
     description = 'Data Management Magic Tools.',
     packages = find_packages(),
+    package_data={'dmagic': ['*.txt']},
     entry_points={'console_scripts':['dmagic = dmagic.__main__:main'],},
     version = open('VERSION').read().strip(),
     zip_safe = False,


### PR DESCRIPTION
## Summary

This PR adds a suite of commands for managing Data Management (DM/Sojourner) experiments directly from the `dmagic` CLI, integrating with both the APS scheduling REST API and the DM Python SDK.

## New commands

| Command | Description |
|---|---|
| `dmagic create` | Interactive beamtime selection from the scheduling system; creates a DM experiment and adds all proposal users |
| `dmagic create-manual` | Create a DM experiment for commissioning runs without a proposal |
| `dmagic delete` | List all DM experiments for the station (last 2 years) and delete one interactively |
| `dmagic email` | Send a Globus data link email to all users on a DM experiment |
| `dmagic add-user` | Add users to an existing DM experiment by badge number (prompts interactively if not given on CLI) |
| `dmagic remove-user` | Remove users from an existing DM experiment by badge number |
| `dmagic daq-start` | Start a DM DAQ for automated file transfer from the analysis machine |
| `dmagic daq-stop` | Stop all running DM DAQs for an experiment |

## Other changes
- Beamline-specific config defaults (site, credentials, Globus UUID, beamline contacts)
- Email message template included in package data
- Bug fix: `AttributeError` when `args.manual` is missing in `create_experiment`
- Docs (`usage.rst`, `about.rst`) and `README.txt` updated for all new commands
