### PR TITLE
Bug fixes, HTML email templates, and install doc overhaul

### DIFF
--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -659,16 +659,18 @@ def main():
             log.info('Experiment name : %s' % exp_name)
             log.info('Globus data link: %s' % data_link)
             log.info(sep)
-        # Write sections appropriate to each command
+        # Write sections appropriate to each command.
+        # Always include 'site' so beamline-specific settings are preserved
+        # rather than being reset to code defaults.
         cmd = sys.argv[1] if len(sys.argv) > 1 else ''
         if cmd == 'init':
             write_sections = ('site',)
         elif cmd == 'create-manual':
-            write_sections = ('manual',)
+            write_sections = ('manual', 'settings', 'site')
         elif cmd in ('daq-start', 'daq-stop'):
-            write_sections = ('local',)
+            write_sections = ('local', 'settings', 'site')
         else:
-            write_sections = ('settings',)
+            write_sections = ('settings', 'site')
         config.write(args.config, args=args, sections=write_sections)
     except RuntimeError as e:
         log.error(str(e))

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -383,7 +383,10 @@ def email(args):
     log.info('Sending e-mail to users on the DM experiment: %s' % args._exp_name)
     args.msg = message.message(args)
     log.info('   Message to users:')
-    log.info('   *** %s' % args.msg.get_content())
+    if args.msg.get_content_maintype() == 'multipart':
+        log.info('   *** (HTML email — open in a mail client to preview)')
+    else:
+        log.info('   *** %s' % args.msg.get_content())
     message.send_email(args)
 
 

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -1,9 +1,6 @@
 import datetime
 import os
 
-from dm import ExperimentDsApi, UserDsApi, ExperimentDaqApi
-from dm.common.exceptions.objectAlreadyExists import ObjectAlreadyExists
-
 from dmagic import log
 from dmagic import authorize
 from dmagic import scheduling
@@ -13,10 +10,18 @@ __author__ = "Alan L Kastengren, Francesco De Carlo"
 __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
 
-exp_api  = ExperimentDsApi()
-user_api = UserDsApi()
-daq_api  = ExperimentDaqApi()
-oee      = ObjectAlreadyExists
+try:
+    from dm import ExperimentDsApi, UserDsApi, ExperimentDaqApi
+    from dm.common.exceptions.objectAlreadyExists import ObjectAlreadyExists
+    exp_api  = ExperimentDsApi()
+    user_api = UserDsApi()
+    daq_api  = ExperimentDaqApi()
+    oee      = ObjectAlreadyExists
+    _DM_AVAILABLE = True
+except ImportError:
+    exp_api = user_api = daq_api = oee = None
+    _DM_AVAILABLE = False
+    log.warning('DM SDK not available: create, delete, email, add-user, remove-user, daq-start, daq-stop commands will not work')
 
 
 def make_experiment_name(args):

--- a/dmagic/message-32id.txt
+++ b/dmagic/message-32id.txt
@@ -21,7 +21,7 @@ below. Both raw and reconstructed files are in the same folder, plus a try_cente
       that you use to access the APS proposal system, but put a &ldquo;d&rdquo; in front of the badge number</li>
   <li>If you forgot your password you can reset it
       <a href="https://www.aps.anl.gov/Users-Information/About-Badges-Identification/Passwords">here</a></li>
-  <li>Go to <code>/gdata/dm/2BM/</code> and search for your data by year-month/PI last name</li>
+  <li>Go to <code>/gdata/dm/32ID/</code> and search for your data by year-month/PI last name</li>
   <li>Set an endpoint on your computer (see
       <a href="https://docs2bm.readthedocs.io/en/latest/source/manual/item_007.html">Globus EndPoint</a>)</li>
   <li>Download the data!</li>
@@ -36,7 +36,7 @@ Our storage capabilities are limited. It will be deleted permanently after that 
 
 <ul>
   <li>Beamline documentation and support:
-      <a href="https://docs2bm.readthedocs.io/">https://docs2bm.readthedocs.io/</a></li>
+      <a href="https://docs32id.readthedocs.io/">https://docs32id.readthedocs.io/</a></li>
   <li>Raw data viewers:
       <a href="https://imagej.net/Fiji">Fiji</a> with the
       <a href="https://github.com/paulscherrerinstitute/ch.psi.imagej.hdf5">HDF plugin</a>,
@@ -50,9 +50,8 @@ Our storage capabilities are limited. It will be deleted permanently after that 
 </ul>
 
 <p>
-Pavel D. Shevchenko<br>
-630-252-1702<br>
-<a href="mailto:pshevchenko@anl.gov">pshevchenko@anl.gov</a><br>
+Viktor Nikitin<br>
+<a href="mailto:vnikitin@anl.gov">vnikitin@anl.gov</a><br>
 Advanced Photon Source
 </p>
 

--- a/dmagic/message.py
+++ b/dmagic/message.py
@@ -26,23 +26,35 @@ def message(args):
     """Read the email template, inject the current Globus data link, and return
     an EmailMessage object ready to send.
 
-    The template file must contain a line starting with 'Data link:' which will
-    be replaced with the actual Globus URL for the experiment.
+    Supports two template formats:
+    - HTML templates (file starts with '<html'): use %%DATA_LINK%% as placeholder;
+      sent as a multipart/alternative HTML email.
+    - Plain-text templates: must contain a line starting with 'Data link:';
+      sent as plain text.
     """
     msg_file = _message_file_path(args)
     with open(msg_file, 'r') as f:
-        lines = f.readlines()
+        content = f.read()
 
     data_link = dm.make_data_link(args)
-    with open(msg_file, 'w') as f:
-        for line in lines:
-            if line.startswith('Data link:'):
-                line = 'Data link: {:s}\n'.format(data_link)
-            f.write(line)
+    is_html = content.lstrip().startswith('<')
 
-    with open(msg_file, 'r') as f:
-        msg = EmailMessage()
-        msg.set_content(f.read())
+    if is_html:
+        content = content.replace(
+            '%%DATA_LINK%%',
+            '<a href="{0}">{0}</a>'.format(data_link))
+    else:
+        lines = content.splitlines(keepends=True)
+        content = ''.join(
+            'Data link: {:s}\n'.format(data_link) if line.startswith('Data link:') else line
+            for line in lines)
+
+    msg = EmailMessage()
+    if is_html:
+        msg.set_content('Please enable HTML to view this email.')
+        msg.add_alternative(content, subtype='html')
+    else:
+        msg.set_content(content)
 
     msg['From']    = args.primary_beamline_contact_email
     msg['Subject'] = 'Important information on APS experiment'
@@ -52,8 +64,7 @@ def message(args):
 def send_email(args):
     """Send the experiment data-access email to all users on the DM experiment.
 
-    Prompts for confirmation before sending. SMTP sending is currently stubbed
-    out — uncomment the smtplib block below when ready to enable.
+    Prompts for confirmation before sending.
     """
     log.info("Send email to users?")
     if not yes_or_no('   *** Yes or No'):
@@ -72,9 +83,6 @@ def send_email(args):
     emails.append(args.primary_beamline_contact_email)
     emails.append(args.secondary_beamline_contact_email)
 
-    log.info('   Would send email to: %s' % ', '.join(emails))
-
-    # Uncomment the block below to enable actual email sending:
     s = smtplib.SMTP('mailhost.anl.gov')
     for em in emails:
         if args.msg['To'] is None:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -200,8 +200,15 @@ html_favicon = 'source/img/dmagic-logo.png'
 # If true, the index is split into individual pages for each letter.
 #html_split_index = False
 
-# If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
+
+html_context = {
+    'display_github': True,
+    'github_user': 'xray-imaging',
+    'github_repo': 'DMagic',
+    'github_version': 'master',
+    'conf_py_path': '/docs/source/',
+}
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -2,126 +2,109 @@
 Install
 =======
 
-This section covers the basics of how to download and install `DMagic <https://github.com/xray-imaging/DMagic>`_.
+This section covers how to install `DMagic <https://github.com/xray-imaging/DMagic>`_ on a new beamline account.
 
 .. contents:: Contents:
    :local:
 
-Installing from source
-======================
+Install
+=======
 
-Install from `Anaconda <https://www.anaconda.com/distribution/>`_ > python3.9
+Requires `Anaconda <https://www.anaconda.com/distribution/>`_ with Python 3.9 or later.
 
-Create and activate a dedicated conda environment::
+Create and activate a conda environment::
 
     (base) $ conda create --name dm python=3.11
     (base) $ conda activate dm
-    (dm) $ 
 
-Clone the  `DMagic <https://github.com/xray-imaging/DMagic>`_ repository
-
-::
+Clone and install DMagic::
 
     (dm) $ git clone https://github.com/xray-imaging/DMagic DMagic
-
-Install DMagic::
-
     (dm) $ cd DMagic
     (dm) $ pip install .
+    (dm) $ pip install pytz requests pyepics
 
-Install all packages listed in the ``envs/requirements.txt`` file::
+Install the APS Data Management SDK::
 
-    (dm) $ conda install pytz
-    (dm) $ conda install requests
-    (dm) $ pip install pyepics
+    (dm) $ conda install apsu::aps-dm-api
 
-Test the installation
-=====================
+.. note::
+    The DM SDK is required for ``create``, ``delete``, ``email``, ``add-user``,
+    ``remove-user``, ``daq-start``, and ``daq-stop``. Without it, ``dmagic show``
+    and ``dmagic tag`` still work and dmagic will print a warning for the other commands.
 
-Before using DMagic you must create a file with default name .scheduling_credentials in the user 
-home directory containing: username|pwd to access the restAPI service.
 
+Configure
+=========
+
+Credentials
+-----------
+
+Create a credentials file for the APS scheduling REST API::
+
+    $ echo "username|password" > ~/.scheduling_credentials
+    $ chmod 600 ~/.scheduling_credentials
+
+Replace ``username`` and ``password`` with your APS beamline scheduling credentials.
+
+DM environment variables
+------------------------
+
+The DM SDK requires environment variables to locate the DM web services. These are
+beamline-specific. Look up the values for your beamline in
+``/home/dm_id/etc/dm.setup.sh`` on any machine where the DM system is configured,
+then add them to ``~/.bashrc``::
+
+    export DM_ROOT_DIR=/home/dm_id/production
+    export DM_DS_WEB_SERVICE_URL=https://<ds-host>:<port>
+    export DM_DAQ_WEB_SERVICE_URL=https://<daq-host>:<port>
+    export DM_CAT_WEB_SERVICE_URL=https://<daq-host>:<cat-port>
+    export DM_PROC_WEB_SERVICE_URL=https://<daq-host>:<proc-port>
+    export DM_APS_DB_WEB_SERVICE_URL=https://<ds-host>:<db-port>
+    export DM_STATION_NAME=<STATION>          # e.g. 2BM or 32ID
+    export DM_LOGIN_FILE=/home/dm_id/etc/.<login-file>
+    export DM_BEAMLINE_NAME=<beamline>        # e.g. 2-BM-A,B or 32-ID-B,C
+
+DMagic configuration file
+--------------------------
+
+Run ``dmagic init`` to create ``~/dmagic.conf`` with default values::
+
+    (dm) $ dmagic init
+
+Then edit the ``[site]`` section to match your beamline. The key fields are:
+
+* ``beamline`` — beamline ID as listed in the `APS scheduling system <https://www.aps.anl.gov/Beamlines/Directory>`_, e.g. ``2-BM-A,B`` or ``32-ID-B,C``
+* ``credentials`` — path to your ``~/.scheduling_credentials`` file
+* ``experiment-type`` — station name used by the DM system, e.g. ``2BM`` or ``32ID``
+* ``primary-beamline-contact-badge`` / ``secondary-beamline-contact-badge`` — badge numbers for beamline staff auto-added to every experiment
+* ``tomoscan-prefix`` — EPICS IOC prefix used by ``dmagic tag``, e.g. ``2bmb:TomoScan:``
+
+See the `Usage <usage.html>`_ page for a full annotated example.
+
+.. note::
+    The ``[site]`` section only needs to be set once. Do not run ``dmagic init``
+    again after configuring it — that would overwrite your settings.
+
+
+Test
+====
 
 ::
 
-    (dm) $ dmagic -h
-    usage: dmagic [-h] [--config FILE]  ...
+    (dm) $ dmagic show
 
-    optional arguments:
-      -h, --help     show this help message and exit
-      --config FILE  File name of configuration
+This should display the currently active proposal for your beamline. If the DM SDK
+is also installed and the environment variables are set correctly::
 
-    Commands:
-      
-        init         Create configuration file
-        show         Show user and experiment info from the APS schedule
-        tag          Update user info EPICS PVs with info from the APS schedule
-
-
-Configuration
-=============
-
-To run DMagic you need to set the beamline name as defined in the `APS scheduling system <https://www.aps.anl.gov/Beamlines/Directory>`_, and the user info PVs where to store the information retrieved from the scheduling system.  If you are using `tomoScan <https://tomoscan.readthedocs.io/en/latest/>`_ these are provided in the 
-beamline specific section `user information <https://tomoscan.readthedocs.io/en/latest/tomoScanApp.html#user-information>`_ section. 
-
-Once you have this information you can update the DMagic configuration i.e. the name of your beamline and the 
-IOC prefix where the PVs are stored at runtime using the --beamline and --tomoscan-prefix options. For more info::
-
-    (dm) $ dmagic show -h
-    usage: dmagic show [-h] [--beamline BEAMLINE] [--set SET] [--tomoscan-prefix TOMOSCAN_PREFIX] [--url URL] [--config FILE] [--verbose]
-    
-    optional arguments:
-      -h, --help            show this help message and exit
-      --beamline BEAMLINE   beamline name as defined at https://www.aps.anl.gov/Beamlines/Directory, e.g. 2-BM-A,B or 7-BM-B or 32-ID-B,C (default: 7-BM-B)
-      --set SET             Number of +/- number days for the current date. Used for setting user info for past/future user groups (default: 0)
-      --tomoscan-prefix TOMOSCAN_PREFIX
-                            The tomoscan prefix, i.e.'7bmb1:' or '2bma:TomoScan:' (default: 7bmb1:)
-      --url URL             URL address of the scheduling system REST API' (default: https://beam-api.aps.anl.gov)
-      --config FILE         File name of configuration (default: /Users/decarlo/dmagic.conf)
-      --verbose             Verbose output (default: True)
-
-If you are not running `tomoScan <https://tomoscan.readthedocs.io/en/latest/>`_ look at the EPICS tools section below.
-
-
-EPICS tools
-===========
-
-If you are not running `tomoScan <https://tomoscan.readthedocs.io/en/latest/>`_:
-
-* Copy and customize in your EPICS ioc boot directory the :download:`experimentInfo.db <../demo/epics/experimentInfo.db>` and :download:`experimentInfo_settings.req <../demo/epics/experimentInfo_settings.req>` files.
-
-* Edit your EPICS ioc start up script by adding (as an example for an IOC named 32idcTXM):
-
-::
-
-    dbLoadRecords("$(TOP)/experimentInfo.db", "P=32idcTXM:")
-
-* Add a link to your main MEDM screen to load the :download:`experiment_info.adl <../demo/epics/experiment_info.adl>`
-
-.. image:: img/medm_screen.png
-  :width: 400
-  :alt: medm screen
+    (dm) $ dmagic create
 
 
 Update
 ======
 
-**dmagic** is constantly updated to include new features. To update your locally installed version::
+::
 
-    (dm) $ cd dmagic
+    (dm) $ cd DMagic
     (dm) $ git pull
     (dm) $ pip install .
-
-
-Dependencies
-============
-
-Install the following packages::
-
-    $ pip install pyepics
-    $ pip install pytz
-    $ pip install requests
-
-.. warning:: If required, edit your .cshrc or .bashrc to set PYEPICS_LIBCA. Example: setenv PYEPICS_LIBCA /APSshare/epics/extensions-base/3.14.12.2-ext1/lib/linux-x86_64/libca.so
-
-


### PR DESCRIPTION
## Summary

- Make DM SDK import optional so `dmagic show` and `dmagic tag` work on machines without the DM SDK installed; other commands print a warning instead of crashing

- Fix critical bug where `config.write()` was resetting the entire `[site]` section to 2BM hardcoded defaults on every command run, breaking multi-beamline installs (e.g. 32-ID on txmthree)

- Fix `AttributeError: Namespace object has no attribute manual` crash in `dmagic create` when creating a new experiment (the early-return path for existing experiments had masked the bug)

- Convert `message-2bm.txt` to HTML email with Google Slides link, numbered Globus download steps, two "Please make sure" warnings in red, and Pavel Shevchenko signature; add `message-32id.txt` with the same structure for 32-ID; update `message.py` to detect HTML templates, replace `%%DATA_LINK%%` with a clickable anchor tag, send as `multipart/alternative`, and stop writing the URL back to the template file on disk

- Rewrite `docs/source/install.rst` to reflect current install procedure: consolidated pip dependencies, `conda install apsu::aps-dm-api` for the DM SDK, credentials file setup, DM environment variables from `dm.setup.sh`, and `dmagic init` with key `[site]` fields explained; remove stale EPICS tools and Dependencies sections

- Replace "View page source" with "Edit on GitHub" in the RTD theme by setting `html_show_sourcelink = False` and adding `html_context` with the xray-imaging/DMagic GitHub repo info

## Test plan

- [ ] `dmagic show` and `dmagic tag` work on a machine without `aps-dm-api` installed (warning printed, no crash)
- [ ] `dmagic show` / `dmagic create` on a non-2BM beamline no longer resets `[site]` to 2BM defaults after running
- [ ] `dmagic create` successfully creates a new experiment without `AttributeError`
- [ ] `dmagic email` sends an HTML email with red warnings, numbered Globus steps, and a clickable data link
- [ ] Install from scratch on a new account following the updated `install.rst` completes without issues
- [ ] Docs pages show "Edit on GitHub" in the top-right corner

🤖 Generated with [Claude Code](https://claude.com/claude-code)
