### PR TITLE
Improve dmagic email: HTML templates, preview, Slides lookup, and send options

### DIFF
--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -400,8 +400,10 @@ def email(args):
     users = dm.list_users_this_dm_exp(args)
     if users:
         emails = dm.make_user_email_list(users)
-        emails.append(args.primary_beamline_contact_email)
-        emails.append(args.secondary_beamline_contact_email)
+        for contact in (args.primary_beamline_contact_email,
+                        args.secondary_beamline_contact_email):
+            if contact not in emails:
+                emails.append(contact)
         log.info('   Recipients:')
         for em in emails:
             log.info('      %s' % em)

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -386,11 +386,26 @@ def email(args):
 
     log.info('Sending e-mail to users on the DM experiment: %s' % args._exp_name)
     args.msg = message.message(args)
-    log.info('   Message to users:')
+    log.info('   Message preview:')
+    log.info('   ' + '=' * 60)
     if args.msg.get_content_maintype() == 'multipart':
-        log.info('   *** (HTML email — open in a mail client to preview)')
+        html_content = args.msg.get_payload()[1].get_payload(decode=True).decode()
+        for line in message.html_to_text(html_content).splitlines():
+            log.info('   %s' % line)
     else:
-        log.info('   *** %s' % args.msg.get_content())
+        for line in args.msg.get_content().splitlines():
+            log.info('   %s' % line)
+    log.info('   ' + '=' * 60)
+
+    users = dm.list_users_this_dm_exp(args)
+    if users:
+        emails = dm.make_user_email_list(users)
+        emails.append(args.primary_beamline_contact_email)
+        emails.append(args.secondary_beamline_contact_email)
+        log.info('   Recipients:')
+        for em in emails:
+            log.info('      %s' % em)
+
     message.send_email(args)
 
 

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -69,6 +69,7 @@ from dmagic import authorize
 from dmagic import utils
 from dmagic import dm
 from dmagic import message
+from dmagic import tomolog as tomolog_utils
 
 
 def init_PVs(args):
@@ -379,6 +380,9 @@ def email(args):
 
     args._exp_name   = exps[choice]['name']
     args._year_month = exps[choice].get('rootPath', '')
+
+    gup = args._exp_name.rsplit('-', 1)[-1]
+    args.presentation_url = tomolog_utils.get_presentation_url(gup, args.tomolog_home)
 
     log.info('Sending e-mail to users on the DM experiment: %s' % args._exp_name)
     args.msg = message.message(args)

--- a/dmagic/config.py
+++ b/dmagic/config.py
@@ -78,6 +78,10 @@ SECTIONS['site'] = {
         'type': str,
         'default': 'decarlo@anl.gov',
         'help': 'Email address of secondary beamline contact'},
+    'tomolog-home': {
+        'default': '/home/beams/TOMO',
+        'type': str,
+        'help': "Home directory of the account running tomolog; .tomolog history file is read from here"},
     'tomoscan-prefix': {
         'default': '2bmb:TomoScan:',
         'type': str,

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -242,7 +242,16 @@ def list_experiments_by_station(station, years=2):
                 pass
         return sorted(filtered, key=lambda e: e.get('rootPath', ''), reverse=True)
     except Exception as e:
-        log.error('Could not list DM experiments for station %s: %s' % (station, str(e)))
+        error_msg = str(e)
+        log.error('Could not list DM experiments for station %s: %s' % (station, error_msg))
+        if 'incorrect username or password' in error_msg.lower():
+            import os
+            login_file = os.environ.get('DM_LOGIN_FILE', 'not set')
+            log.error('   DM authentication failed. Check that DM_LOGIN_FILE is accessible.')
+            log.error('   DM_LOGIN_FILE = %s' % login_file)
+            if login_file != 'not set' and not os.path.isfile(login_file):
+                log.error('   File not found — this machine may not have the required NFS mount.')
+                log.error('   Run DM commands from a beamline control machine (e.g. arcturus).')
         return []
 
 

--- a/dmagic/message-2bm.txt
+++ b/dmagic/message-2bm.txt
@@ -19,10 +19,10 @@ It will be deleted permanently after that time.</strong></p>
   <li>Login into Globus with your personal Globus credential</li>
   <li>Login to the APS data management system using the same badge number/password combination
       that you use to access the APS proposal system, but put a &ldquo;d&rdquo; in front of the badge number</li>
-  <li>If you forgot your password you can reset it
-      <a href="https://www.aps.anl.gov/Users-Information/About-Badges-Identification/Passwords">here</a></li>
+  <li>If you forgot your password please contact the user office at
+      <a href="mailto:apsuser@anl.gov">apsuser@anl.gov</a></li>
   <li>Set an endpoint on your computer (see
-      <a href="https://docs2bm.readthedocs.io/en/latest/source/manual/item_007.html">Globus EndPoint</a>)</li>
+      <a href="https://www.globus.org/globus-connect-personal">Globus EndPoint</a>)</li>
   <li>Raw files are in the <strong>data</strong> folder and reconstructed files in the <strong>analysis</strong> folder,
       together with the try_center folder</li>
   <li>Download the data!</li>

--- a/dmagic/message-2bm.txt
+++ b/dmagic/message-2bm.txt
@@ -5,7 +5,7 @@
 
 <p>Please use this link to access your beamtime log slides:</p>
 
-<p><a href="https://docs.google.com/presentation/u/0/">https://docs.google.com/presentation/u/0/</a></p>
+<p>%%SLIDES_LINK%%</p>
 
 <p style="color: red;"><strong>Please make sure it is copied from our account 3 months from today.
 The number of presentations under a single account is limited.

--- a/dmagic/message-2bm.txt
+++ b/dmagic/message-2bm.txt
@@ -41,9 +41,11 @@ Our storage capabilities are limited. It will be deleted permanently after that 
       <a href="https://github.com/paulscherrerinstitute/ch.psi.imagej.hdf5">HDF plugin</a>,
       <a href="https://support.hdfgroup.org/products/java/hdfview/">HDFView</a>,
       <a href="https://github.com/titusjan/argos">Argos</a></li>
-  <li>Reconstruction scripts:
-      <a href="https://github.com/tomography/tomopy-cli">tomopy-cli</a>
-      (<a href="https://tomopy.readthedocs.io/">tomopy docs</a>)</li>
+  <li>CPU based reconstruction software:
+      <a href="https://github.com/tomography/tomopy-cli">tomopy-cli</a> and
+      <a href="https://tomopy.readthedocs.io/en/stable/">tomopy</a></li>
+  <li>GPU based reconstruction software:
+      <a href="https://tomocupy.readthedocs.io/en/latest/">tomocupy</a></li>
   <li>Interesting dataset? Submit a pull request at
       <a href="https://tomobank.readthedocs.io">tomobank.readthedocs.io</a></li>
 </ul>

--- a/dmagic/message-2bm.txt
+++ b/dmagic/message-2bm.txt
@@ -11,23 +11,22 @@
 The number of presentations under a single account is limited.
 It will be deleted permanently after that time.</strong></p>
 
-<p>Your experiment data has been uploaded to our Globus server. Download it using the instructions
-below. Both raw and reconstructed files are in the same folder, plus a try_center folder.</p>
+<p>Your experiment data has been uploaded to our Globus server. Download it using the instructions below.</p>
+
+<p>Data link: %%DATA_LINK%%</p>
 
 <ol>
   <li>Login into Globus with your personal Globus credential</li>
-  <li>Go to &ldquo;Collection/Search&rdquo; and search for the APS data; select <strong>aps#data</strong></li>
   <li>Login to the APS data management system using the same badge number/password combination
       that you use to access the APS proposal system, but put a &ldquo;d&rdquo; in front of the badge number</li>
   <li>If you forgot your password you can reset it
       <a href="https://www.aps.anl.gov/Users-Information/About-Badges-Identification/Passwords">here</a></li>
-  <li>Go to <code>/gdata/dm/2BM/</code> and search for your data by year-month/PI last name</li>
   <li>Set an endpoint on your computer (see
       <a href="https://docs2bm.readthedocs.io/en/latest/source/manual/item_007.html">Globus EndPoint</a>)</li>
+  <li>Raw files are in the <strong>data</strong> folder and reconstructed files in the <strong>analysis</strong> folder,
+      together with the try_center folder</li>
   <li>Download the data!</li>
 </ol>
-
-<p>Data link: %%DATA_LINK%%</p>
 
 <p style="color: red;"><strong>Please make sure all your data is downloaded 3 months from today.
 Our storage capabilities are limited. It will be deleted permanently after that time.</strong></p>

--- a/dmagic/message-32id.txt
+++ b/dmagic/message-32id.txt
@@ -19,10 +19,10 @@ It will be deleted permanently after that time.</strong></p>
   <li>Login into Globus with your personal Globus credential</li>
   <li>Login to the APS data management system using the same badge number/password combination
       that you use to access the APS proposal system, but put a &ldquo;d&rdquo; in front of the badge number</li>
-  <li>If you forgot your password you can reset it
-      <a href="https://www.aps.anl.gov/Users-Information/About-Badges-Identification/Passwords">here</a></li>
+  <li>If you forgot your password please contact the user office at
+      <a href="mailto:apsuser@anl.gov">apsuser@anl.gov</a></li>
   <li>Set an endpoint on your computer (see
-      <a href="https://docs2bm.readthedocs.io/en/latest/source/manual/item_007.html">Globus EndPoint</a>)</li>
+      <a href="https://www.globus.org/globus-connect-personal">Globus EndPoint</a>)</li>
   <li>Raw files are in the <strong>data</strong> folder and reconstructed files in the <strong>analysis</strong> folder,
       together with the try_center folder</li>
   <li>Download the data!</li>

--- a/dmagic/message-32id.txt
+++ b/dmagic/message-32id.txt
@@ -5,7 +5,7 @@
 
 <p>Please use this link to access your beamtime log slides:</p>
 
-<p><a href="https://docs.google.com/presentation/u/0/">https://docs.google.com/presentation/u/0/</a></p>
+<p>%%SLIDES_LINK%%</p>
 
 <p style="color: red;"><strong>Please make sure it is copied from our account 3 months from today.
 The number of presentations under a single account is limited.

--- a/dmagic/message-32id.txt
+++ b/dmagic/message-32id.txt
@@ -11,23 +11,22 @@
 The number of presentations under a single account is limited.
 It will be deleted permanently after that time.</strong></p>
 
-<p>Your experiment data has been uploaded to our Globus server. Download it using the instructions
-below. Both raw and reconstructed files are in the same folder, plus a try_center folder.</p>
+<p>Your experiment data has been uploaded to our Globus server. Download it using the instructions below.</p>
+
+<p>Data link: %%DATA_LINK%%</p>
 
 <ol>
   <li>Login into Globus with your personal Globus credential</li>
-  <li>Go to &ldquo;Collection/Search&rdquo; and search for the APS data; select <strong>aps#data</strong></li>
   <li>Login to the APS data management system using the same badge number/password combination
       that you use to access the APS proposal system, but put a &ldquo;d&rdquo; in front of the badge number</li>
   <li>If you forgot your password you can reset it
       <a href="https://www.aps.anl.gov/Users-Information/About-Badges-Identification/Passwords">here</a></li>
-  <li>Go to <code>/gdata/dm/32ID/</code> and search for your data by year-month/PI last name</li>
   <li>Set an endpoint on your computer (see
       <a href="https://docs2bm.readthedocs.io/en/latest/source/manual/item_007.html">Globus EndPoint</a>)</li>
+  <li>Raw files are in the <strong>data</strong> folder and reconstructed files in the <strong>analysis</strong> folder,
+      together with the try_center folder</li>
   <li>Download the data!</li>
 </ol>
-
-<p>Data link: %%DATA_LINK%%</p>
 
 <p style="color: red;"><strong>Please make sure all your data is downloaded 3 months from today.
 Our storage capabilities are limited. It will be deleted permanently after that time.</strong></p>

--- a/dmagic/message-32id.txt
+++ b/dmagic/message-32id.txt
@@ -41,9 +41,11 @@ Our storage capabilities are limited. It will be deleted permanently after that 
       <a href="https://github.com/paulscherrerinstitute/ch.psi.imagej.hdf5">HDF plugin</a>,
       <a href="https://support.hdfgroup.org/products/java/hdfview/">HDFView</a>,
       <a href="https://github.com/titusjan/argos">Argos</a></li>
-  <li>Reconstruction scripts:
-      <a href="https://github.com/tomography/tomopy-cli">tomopy-cli</a>
-      (<a href="https://tomopy.readthedocs.io/">tomopy docs</a>)</li>
+  <li>CPU based reconstruction software:
+      <a href="https://github.com/tomography/tomopy-cli">tomopy-cli</a> and
+      <a href="https://tomopy.readthedocs.io/en/stable/">tomopy</a></li>
+  <li>GPU based reconstruction software:
+      <a href="https://tomocupy.readthedocs.io/en/latest/">tomocupy</a></li>
   <li>Interesting dataset? Submit a pull request at
       <a href="https://tomobank.readthedocs.io">tomobank.readthedocs.io</a></li>
 </ul>

--- a/dmagic/message.py
+++ b/dmagic/message.py
@@ -155,8 +155,10 @@ def send_email(args):
         if not emails:
             log.warning('   No user emails found on the DM experiment')
 
-        emails.append(args.primary_beamline_contact_email)
-        emails.append(args.secondary_beamline_contact_email)
+        for contact in (args.primary_beamline_contact_email,
+                        args.secondary_beamline_contact_email):
+            if contact not in emails:
+                emails.append(contact)
 
     s = smtplib.SMTP('mailhost.anl.gov')
     for em in emails:

--- a/dmagic/message.py
+++ b/dmagic/message.py
@@ -116,8 +116,17 @@ def message(args):
     else:
         msg.set_content(content)
 
+    exp_name = getattr(args, '_exp_name', '')
+    parts = exp_name.split('-')
+    if len(parts) >= 4:
+        pi_last = parts[2]
+        gup     = parts[-1]
+        subject = 'Important information for APS experiment GUP-{} {}'.format(gup, pi_last)
+    else:
+        subject = 'Important information for APS experiment'
+
     msg['From']    = args.primary_beamline_contact_email
-    msg['Subject'] = 'Important information on APS experiment'
+    msg['Subject'] = subject
     return msg
 
 

--- a/dmagic/message.py
+++ b/dmagic/message.py
@@ -117,11 +117,8 @@ def message(args):
         msg.set_content(content)
 
     exp_name = getattr(args, '_exp_name', '')
-    parts = exp_name.split('-')
-    if len(parts) >= 4:
-        pi_last = parts[2]
-        gup     = parts[-1]
-        subject = 'Important information for APS experiment GUP-{} {}'.format(gup, pi_last)
+    if exp_name:
+        subject = 'Important information for APS experiment {}'.format(exp_name)
     else:
         subject = 'Important information for APS experiment'
 

--- a/dmagic/message.py
+++ b/dmagic/message.py
@@ -43,6 +43,12 @@ def message(args):
         content = content.replace(
             '%%DATA_LINK%%',
             '<a href="{0}">{0}</a>'.format(data_link))
+        slides_url = getattr(args, 'presentation_url', None)
+        if slides_url:
+            slides_html = '<a href="{0}">{0}</a>'.format(slides_url)
+        else:
+            slides_html = '(no beamtime log slides found for this proposal)'
+        content = content.replace('%%SLIDES_LINK%%', slides_html)
     else:
         lines = content.splitlines(keepends=True)
         content = ''.join(

--- a/dmagic/message.py
+++ b/dmagic/message.py
@@ -1,8 +1,10 @@
 import os
+import re
 import pathlib
 import smtplib
 
 from email.message import EmailMessage
+from html.parser import HTMLParser
 
 from dmagic import log
 from dmagic import dm
@@ -15,6 +17,58 @@ def yes_or_no(question):
         log.warning("Input yes or no")
         answer = str(input(question + " (Y/N): ")).lower().strip()
     return answer[0] == "y"
+
+
+class _HtmlToTextParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self._parts   = []
+        self._skip    = 0
+        self._in_ol   = False
+        self._ol_idx  = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag in ('style', 'script'):
+            self._skip += 1
+        elif tag in ('p', 'div', 'h1', 'h2', 'h3'):
+            self._parts.append('\n')
+        elif tag == 'br':
+            self._parts.append('\n')
+        elif tag == 'ol':
+            self._in_ol = True
+            self._ol_idx = 0
+            self._parts.append('\n')
+        elif tag == 'ul':
+            self._in_ol = False
+            self._parts.append('\n')
+        elif tag == 'li':
+            if self._in_ol:
+                self._ol_idx += 1
+                self._parts.append('\n%d. ' % self._ol_idx)
+            else:
+                self._parts.append('\n- ')
+
+    def handle_endtag(self, tag):
+        if tag in ('style', 'script'):
+            self._skip -= 1
+        elif tag in ('p', 'div', 'ol', 'ul'):
+            self._parts.append('\n')
+
+    def handle_data(self, data):
+        if not self._skip:
+            self._parts.append(data)
+
+    def get_text(self):
+        text = ''.join(self._parts)
+        text = re.sub(r'\n{3,}', '\n\n', text)
+        return text.strip()
+
+
+def html_to_text(html_content):
+    """Strip HTML tags and return a readable plain-text version."""
+    parser = _HtmlToTextParser()
+    parser.feed(html_content)
+    return parser.get_text()
 
 
 def _message_file_path(args):
@@ -67,27 +121,42 @@ def message(args):
     return msg
 
 
+def _send_prompt():
+    """Prompt Y / N / T (test).  Returns 'y', 'n', or 't'."""
+    log.info("Send email to users?")
+    answer = str(input('   *** Yes / No / Test (Y/N/T): ')).lower().strip()
+    while answer not in ('y', 'yes', 'n', 'no', 't', 'test'):
+        log.warning("Input Y (send to all), N (cancel), or T (test: send only to secondary beamline contact)")
+        answer = str(input('   *** Yes / No / Test (Y/N/T): ')).lower().strip()
+    return answer[0]
+
+
 def send_email(args):
     """Send the experiment data-access email to all users on the DM experiment.
 
-    Prompts for confirmation before sending.
+    Prompts for Y (send to all), N (cancel), or T (test: secondary beamline contact only).
     """
-    log.info("Send email to users?")
-    if not yes_or_no('   *** Yes or No'):
+    choice = _send_prompt()
+
+    if choice == 'n':
         log.warning('   *** Message not sent')
         return False
 
-    users = dm.list_users_this_dm_exp(args)
-    if users is None:
-        log.error('   Cannot send email: no DM experiment found. Have you run "dmagic create" yet?')
-        return False
+    if choice == 't':
+        emails = [args.secondary_beamline_contact_email]
+        log.info('   *** TEST mode: sending only to secondary beamline contact')
+    else:
+        users = dm.list_users_this_dm_exp(args)
+        if users is None:
+            log.error('   Cannot send email: no DM experiment found. Have you run "dmagic create" yet?')
+            return False
 
-    emails = dm.make_user_email_list(users)
-    if not emails:
-        log.warning('   No user emails found on the DM experiment')
+        emails = dm.make_user_email_list(users)
+        if not emails:
+            log.warning('   No user emails found on the DM experiment')
 
-    emails.append(args.primary_beamline_contact_email)
-    emails.append(args.secondary_beamline_contact_email)
+        emails.append(args.primary_beamline_contact_email)
+        emails.append(args.secondary_beamline_contact_email)
 
     s = smtplib.SMTP('mailhost.anl.gov')
     for em in emails:

--- a/dmagic/tomolog.py
+++ b/dmagic/tomolog.py
@@ -1,0 +1,65 @@
+"""
+Read the tomolog history file (.tomolog) to retrieve the Google Slides
+presentation URL for a given GUP proposal number.
+
+The .tomolog file is a YAML list of dicts written by the tomolog package.
+Each entry has at minimum: gup, date, presentation_url.
+"""
+
+import os
+import yaml
+
+from dmagic import log
+
+TOMOLOG_FILE = '.tomolog'
+
+
+def get_presentation_url(gup, tomolog_home):
+    """Return the most recent Google Slides presentation URL for *gup*.
+
+    Reads ``{tomolog_home}/.tomolog``, filters entries matching the given
+    GUP number, sorts by the ``date`` field, and returns the
+    ``presentation_url`` of the most recent entry.
+
+    Parameters
+    ----------
+    gup : str or int
+        GUP proposal number to search for.
+    tomolog_home : str
+        Directory containing the ``.tomolog`` file.
+
+    Returns
+    -------
+    str or None
+        Presentation URL, or None if not found or file cannot be read.
+    """
+    tomolog_path = os.path.join(tomolog_home, TOMOLOG_FILE)
+
+    if not os.path.isfile(tomolog_path):
+        log.warning('tomolog history file not found: %s' % tomolog_path)
+        return None
+
+    try:
+        with open(tomolog_path, 'r') as f:
+            history = yaml.safe_load(f)
+    except Exception as e:
+        log.warning('Could not read tomolog history file %s: %s' % (tomolog_path, str(e)))
+        return None
+
+    if not isinstance(history, list):
+        log.warning('Unexpected format in tomolog history file: %s' % tomolog_path)
+        return None
+
+    gup_str = str(gup).strip()
+    matches = [entry for entry in history
+               if isinstance(entry, dict) and str(entry.get('gup', '')).strip() == gup_str
+               and entry.get('presentation_url')]
+
+    if not matches:
+        log.warning('No tomolog entry found for GUP %s in %s' % (gup_str, tomolog_path))
+        return None
+
+    matches.sort(key=lambda e: str(e.get('date', '')), reverse=True)
+    url = matches[0]['presentation_url']
+    log.info('Found presentation URL for GUP %s: %s' % (gup_str, url))
+    return url

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -22,7 +22,7 @@ Clone and install DMagic::
     (dm) $ git clone https://github.com/xray-imaging/DMagic DMagic
     (dm) $ cd DMagic
     (dm) $ pip install .
-    (dm) $ pip install pytz requests pyepics
+    (dm) $ pip install pytz pyyaml requests pyepics
 
 Install the APS Data Management SDK::
 

--- a/envs/requirements.txt
+++ b/envs/requirements.txt
@@ -1,3 +1,4 @@
 pytz
+pyyaml
 requests
 pyepics


### PR DESCRIPTION
## Summary

This PR consolidates a series of improvements to `dmagic email`, the
HTML email templates, the install documentation, and developer experience.

### Install documentation (`docs/source/install.rst`)
- Rewrote install instructions to reflect the real setup experience on a
  new machine: conda env creation, `pip install`, `conda install apsu::aps-dm-api`
- Added credentials file setup, DM environment variables block (sourced
  from `dm.setup.sh`), and `dmagic init` walkthrough with key `[site]`
  fields
- Removed stale EPICS tools section and duplicate Dependencies appendix

### RTD / Sphinx theme (`docs/conf.py`)
- Replaced "View page source" with "Edit on GitHub" using `html_context`
  pointing to `xray-imaging/DMagic` master branch

### HTML email templates (`dmagic/message-2bm.txt`, `dmagic/message-32id.txt`)
- Converted templates to HTML with styled paragraphs, numbered Globus
  download steps, and red "please make sure" warnings
- Added `%%SLIDES_LINK%%` placeholder for beamtime log Google Slides URL
- Moved data link above the download steps
- Removed obsolete aps#data collection-search and `/gdata/dm/` path-search steps
- Clarified folder layout: raw files in `data/`, reconstructed in `analysis/`
- Split reconstruction software into CPU (tomopy-cli, tomopy) and GPU (tomocupy)
- Updated password-reset text to contact `apsuser@anl.gov` instead of a
  broken link; updated Globus EndPoint link to `globus.org/globus-connect-personal`

### Email logic (`dmagic/message.py`, `dmagic/__main__.py`)
- `message.py`: HTML detection, `%%DATA_LINK%%` / `%%SLIDES_LINK%%`
  substitution, multipart/alternative sending
- Added `_HtmlToTextParser` and `html_to_text()` to render a readable
  plain-text preview of the HTML email in the logger (numbered lists preserved)
- Before the Y/N prompt, log a full message preview between `===` separators
  and list all recipient addresses
- Replaced Y/N prompt with Y / N / T (test): T sends only to the secondary
  beamline contact for template verification without emailing all users
- Fixed duplicate emails: beamline contacts that are already DM experiment
  members are no longer appended a second time
- Email subject now includes the experiment name: `Important information for
  APS experiment YYYY-MM-{PI}-{GUP}`
- Improved DM authentication error message when `DM_LOGIN_FILE` is not
  accessible (NFS not mounted on dev machines)

### Google Slides lookup (`dmagic/tomolog.py`, `dmagic/config.py`)
- New `dmagic/tomolog.py` reads `{tomolog_home}/.tomolog` (YAML written by
  the tomolog package), filters by GUP number, and returns the most recent
  `presentation_url`
- Added `tomolog-home` config parameter to `[site]` section
- Falls back gracefully with a warning if the file is missing or the GUP is
  not found

## Test plan
- [ ] `dmagic email` on `2bmb@arcturus`: verify preview shows correct Slides
  URL and Globus data link, recipient list is correct (no duplicates)
- [ ] Reply T at prompt: confirm email received only at secondary contact
- [ ] Reply Y at prompt: confirm all experiment users receive exactly one email
- [ ] Check email subject line matches `YYYY-MM-PI-GUP` format
- [ ] `dmagic show` on a machine without DM SDK installed: confirm no import error
- [ ] Fresh install on new account: follow updated `install.rst` end-to-end
