### PR TITLE
Add list-users command and surface additional proposal fields

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -18,6 +18,18 @@ Key Commands
 - dmagic tag           : Fetches the same scheduling data and writes it into EPICS
                          Process Variables (PVs) on the beamline's TomoScan IOC.
                          Populates UserName, UserEmail, ProposalNumber, ProposalTitle, etc.
+                         If no proposal is found in the scheduling system, logs a clear
+                         message and suggests running 'dmagic create-manual' followed by
+                         'dmagic tag-manual'.
+
+- dmagic tag-manual    : Interactively lists all DM experiments for the station (both
+                         scheduling-based and manually created, sorted newest first) and
+                         lets the operator choose which one to write to the EPICS PVs.
+                         Useful for commissioning runs with no scheduling proposal, or
+                         when sneaking in a sample from a different user group. For
+                         non-zero GUP experiments it fetches full PI info from the
+                         scheduling system; for manually created ones (GUP=0) it derives
+                         the PI last name from the experiment name.
 
 - dmagic create        : Creates a DM experiment on Sojourner for a proposal-based
                          beamtime. Lists all beamtimes in the current run, prompts for

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -148,6 +148,20 @@ def show(args):
         proposal_start_date  = scheduling.get_proposal_starting_date(proposal)
         proposal_start       = dt.datetime.fromisoformat(utils.fix_iso(proposal['startTime']))
         proposal_end         = dt.datetime.fromisoformat(utils.fix_iso(proposal['endTime']))
+
+        beamtime         = proposal.get('beamtime', {})
+        prop_obj         = beamtime.get('proposal', {})
+        prop_type        = prop_obj.get('proposalType', {}).get('display', 'N/A')
+        granted_shifts   = beamtime.get('grantedShifts', 'N/A')
+        scheduled_shifts = beamtime.get('scheduledShifts', 'N/A')
+        proprietary      = prop_obj.get('proprietaryFlag', 'N/A')
+        mail_in          = prop_obj.get('mailInFlag', 'N/A')
+        submitted_raw    = prop_obj.get('submittedDate', '')
+        try:
+            submitted = dt.datetime.fromisoformat(utils.fix_iso(submitted_raw)).strftime('%Y-%m-%d')
+        except Exception:
+            submitted = submitted_raw or 'N/A'
+
         log.info("\tRun: %s" % run)
         log.info("\tPI Name: %s %s" % (pi_name, pi_last_name))
         log.info("\tPI affiliation: %s" % (pi_affiliation))
@@ -155,7 +169,11 @@ def show(args):
         log.info("\tPI badge: %s" % (pi_badge))
         log.info("\tProposal GUP: %s" % (proposal_id))
         log.info("\tProposal Title: %s" % (proposal_title))
-        log.info("\tStart date: %s" % (proposal_start_date))        
+        log.info("\tProposal type: %s" % prop_type)
+        log.info("\tSubmitted: %s" % submitted)
+        log.info("\tGranted shifts: %s  (scheduled: %s)" % (granted_shifts, scheduled_shifts))
+        log.info("\tProprietary: %s  |  Mail-in: %s" % (proprietary, mail_in))
+        log.info("\tStart date: %s" % (proposal_start_date))
         log.info("\tStart time: %s" % (proposal_start))
         log.info("\tEnd Time: %s" % (proposal_end))
         log.info("\tUser email address: ")

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -532,6 +532,63 @@ def stop_daq(args):
     dm.stop_daq(exp_name)
 
 
+def _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date):
+    """Initialize EPICS PVs, verify connectivity, and write user/experiment fields.
+
+    Parameters
+    ----------
+    args         : CLI args (needs tomoscan_prefix, epics_conn_timeout)
+    pi           : dict with keys firstName, lastName, institution, email, badge
+    proposal_num : str — GUP number or manual identifier
+    proposal_title : str
+    exp_date     : str — 'YYYY-MM'
+
+    Returns True on success, False if the IOC is unreachable.
+    """
+    user_pvs     = init_PVs(args)
+    probe_keys   = ('user_info_update_time', 'pi_name')
+    conn_timeout = getattr(args, 'epics_conn_timeout', 1.0)
+
+    missing = []
+    for k in probe_keys:
+        pv = user_pvs.get(k)
+        if pv is None:
+            continue
+        if not pv.wait_for_connection(timeout=conn_timeout):
+            missing.append(pv.pvname)
+
+    if missing:
+        log.error("EPICS IOC %s not reachable" % args.tomoscan_prefix)
+        log.error("Verify tomoscan_prefix=%s is running" % args.tomoscan_prefix)
+        log.error("or select a different IOC by using the --tomoscan-prefix option")
+        return False
+
+    log.info("User/Experiment PV update")
+    user_pvs['pi_name'].put(pi['firstName'])
+    log.info('Updating pi_name EPICS PV with: %s' % pi['firstName'])
+    user_pvs['pi_last_name'].put(pi['lastName'])
+    log.info('Updating pi_last_name EPICS PV with: %s' % pi['lastName'])
+    user_pvs['pi_affiliation'].put(pi['institution'])
+    log.info('Updating pi_affiliation EPICS PV with: %s' % pi['institution'])
+    user_pvs['pi_email'].put(pi['email'])
+    log.info('Updating pi_email EPICS PV with: %s' % pi['email'])
+    user_pvs['pi_badge'].put(pi['badge'])
+    log.info('Updating pi_badge EPICS PV with: %s' % pi['badge'])
+
+    us_central_tz  = zoneinfo.ZoneInfo("America/Chicago")
+    local_time_iso = datetime.datetime.now().replace(tzinfo=us_central_tz).isoformat()
+    user_pvs['user_info_update_time'].put(local_time_iso)
+    log.info('Updating user_info_update_time EPICS PV with: %s' % local_time_iso)
+
+    user_pvs['proposal_number'].put(proposal_num)
+    log.info('Updating proposal_number EPICS PV with: %s' % proposal_num)
+    user_pvs['proposal_title'].put(proposal_title)
+    log.info('Updating proposal_title EPICS PV with: %s' % proposal_title)
+    user_pvs['experiment_date'].put(exp_date)
+    log.info('Updating experiment_date EPICS PV with: %s' % exp_date)
+    return True
+
+
 def tag(args):
     """
     Update the EPICS PVs with user and experiment information associated with the current experiment
@@ -540,83 +597,115 @@ def tag(args):
     ----------
     args : parameters passed at the CLI, see config.py for full options
     """
-    # set the experiment date 
     now = datetime.datetime.today()
     log.info("Today's date: %s" % now)
 
-    auth      = authorize.basic(args.credentials)
-    run       = scheduling.current_run(auth, args)
+    auth   = authorize.basic(args.credentials)
+    run    = scheduling.current_run(auth, args)
     output = scheduling.beamtime_requests(run, auth, args)
-    proposals = output[0]['activities']
-    # pprint.pprint(proposals, compact=True)
-    #proposals = scheduling.beamtime_requests(run, auth, args)
+
+    proposals = None
+    try:
+        proposals = output[0]['activities']
+    except (IndexError, TypeError):
+        pass
 
     if not proposals:
-        log.error('No valid current experiment')
+        log.error('No proposal found in the scheduling system for this run')
+        log.error("Create one with 'dmagic create' (or 'dmagic create-manual' for commissioning)")
+        log.error("then run 'dmagic tag-manual' to pick it and update the EPICS PVs")
         return None
     try:
         log.error(proposals['message'])
         return None
-    except:
+    except Exception:
         pass
 
     proposal = scheduling.get_current_proposal(proposals, args)
-
-    if proposal != None:
-        # get PI information
-        pi = scheduling.get_current_pi(proposal)
-
-        user_pvs = init_PVs(args)
-
-        # Verify IOC/PVs are reachable before attempting any puts
-        probe_keys = ('user_info_update_time', 'pi_name')  # pick PVs that always exist
-        conn_timeout = getattr(args, 'epics_conn_timeout', 1.0)  # optional new arg; fallback 1s
-
-        missing = []
-        for k in probe_keys:
-            pv = user_pvs.get(k)
-            if pv is None:
-                continue
-            if not pv.wait_for_connection(timeout=conn_timeout):
-                missing.append(pv.pvname)
-
-        if missing:
-            log.error("EPICS IOC %s not reachable" % (args.tomoscan_prefix))
-            log.error("Verify tomoscan_prefix=%s is running " % (args.tomoscan_prefix))
-            log.error("or select select a different IOC by using the --tomoscan-prefix option")
-            return None
-
-
-        log.info("User/Experiment PV update")
-        user_pvs['pi_name'].put(pi['firstName'])
-        log.info('Updating pi_name EPICS PV with: %s' % pi['firstName'])
-        user_pvs['pi_last_name'].put(pi['lastName'])    
-        log.info('Updating pi_last_name EPICS PV with: %s' % pi['lastName'])    
-        user_pvs['pi_affiliation'].put(pi['institution'])
-        log.info('Updating pi_affiliation EPICS PV with: %s' % pi['institution'])
-        user_pvs['pi_email'].put(pi['email'])
-        log.info('Updating pi_email EPICS PV with: %s' % pi['email'])
-        user_pvs['pi_badge'].put(pi['badge'])
-        log.info('Updating pi_badge EPICS PV with: %s' % pi['badge'])
-
-        # set iso format time
-        us_central_tz = zoneinfo.ZoneInfo("America/Chicago")
-        local_time_iso = datetime.datetime.now().replace(tzinfo=us_central_tz).isoformat()
-        user_pvs['user_info_update_time'].put(local_time_iso)
-        log.info('Updating user_info_update_time EPICS PV with: %s' % local_time_iso)
-        
-        # get experiment information
-        user_pvs['proposal_number'].put(str(scheduling.get_current_proposal_id(proposal)))
-        log.info('Updating proposal_number EPICS PV with: %s' % scheduling.get_current_proposal_id(proposal))
-        user_pvs['proposal_title'].put(str(scheduling.get_current_proposal_title(proposal)))
-        log.info('Updating proposal_title EPICS PV with: %s' % scheduling.get_current_proposal_title(proposal))
-        #Make the start date of the experiment into a year - month
-        start_datetime = datetime.datetime.strptime(utils.fix_iso(proposal['startTime']),'%Y-%m-%dT%H:%M:%S%z')
-        user_pvs['experiment_date'].put(start_datetime.strftime('%Y-%m'))
-        log.info('Updating experiment_date EPICS PV with: %s' % start_datetime.strftime('%Y-%m'))
-    else:
+    if proposal is None:
         time_now = datetime.datetime.now().astimezone() + dt.timedelta(args.set)
-        log.warning('No proposal run on %s during %s' % (time_now, run))
+        log.warning('No proposal active on %s during run %s' % (time_now, run))
+        log.warning("Use 'dmagic tag-manual' to select an experiment manually")
+        return None
+
+    pi             = scheduling.get_current_pi(proposal)
+    proposal_num   = str(scheduling.get_current_proposal_id(proposal))
+    proposal_title = str(scheduling.get_current_proposal_title(proposal))
+    start_datetime = datetime.datetime.strptime(utils.fix_iso(proposal['startTime']), '%Y-%m-%dT%H:%M:%S%z')
+    exp_date       = start_datetime.strftime('%Y-%m')
+
+    _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date)
+
+
+def tag_manual(args):
+    """
+    Interactively select a DM experiment and update EPICS PVs with its information.
+
+    Lists all DM experiments for the station (scheduling-based and manually created)
+    sorted newest first, then lets the operator choose which one to activate.
+    Useful when sneaking in a sample from a different user group, or when running
+    commissioning with no proposal in the scheduling system.
+
+    Parameters
+    ----------
+    args : parameters passed at the CLI, see config.py for full options
+    """
+    now = datetime.datetime.today()
+    log.info("Today's date: %s" % now)
+
+    exps = dm.list_experiments_by_station(args.experiment_type)
+    if not exps:
+        log.error('No DM experiments found for station %s' % args.experiment_type)
+        return
+
+    log.info('Found %d DM experiment(s) for station %s:' % (len(exps), args.experiment_type))
+    for i, e in enumerate(exps):
+        start = e.get('startDate', '?')[:10]
+        end   = e.get('endDate',   '?')[:10]
+        desc  = e.get('description', '')[:60]
+        print("  [%2d] %-35s  %s to %s  %s" % (i, e['name'], start, end, desc))
+
+    while True:
+        try:
+            choice = input("\nSelect experiment to tag [0-%d] or 'q' to quit: " % (
+                           len(exps) - 1)).strip()
+            if choice.lower() == 'q':
+                log.info('No experiment selected. Exiting.')
+                return
+            choice = int(choice)
+            if 0 <= choice < len(exps):
+                break
+            print("Please enter a number between 0 and %d" % (len(exps) - 1))
+        except (ValueError, EOFError):
+            print("Invalid input. Please enter a number or 'q' to quit.")
+
+    exp = exps[choice]
+    log.info('Selected DM experiment: %s' % exp['name'])
+
+    # Experiment name format: YYYY-MM-LastName-GUP
+    name_parts     = exp['name'].split('-')
+    pi_last        = name_parts[2] if len(name_parts) >= 4 else ''
+    gup_str        = name_parts[-1] if len(name_parts) >= 4 else '0'
+    proposal_title = exp.get('description', exp['name'])
+    exp_date       = exp.get('rootPath', '')
+
+    # For non-zero GUP numbers try to pull full PI info from the scheduling system
+    pi = None
+    if gup_str.isdigit() and int(gup_str) != 0:
+        try:
+            auth     = authorize.basic(args.credentials)
+            beamtime = scheduling.get_beamtime(gup_str, auth, args)
+            if beamtime is not None:
+                pi = scheduling.get_current_pi(beamtime)
+                log.info('Retrieved full PI info from scheduling system for GUP %s' % gup_str)
+        except Exception as e:
+            log.warning('Could not retrieve PI info from scheduling system: %s' % str(e))
+
+    if pi is None:
+        log.warning('Using PI info parsed from DM experiment name (first name, institution, email, badge will be empty)')
+        pi = {'firstName': '', 'lastName': pi_last, 'institution': '', 'email': '', 'badge': ''}
+
+    _update_tag_pvs(args, pi, gup_str, proposal_title, exp_date)
 
 
 def main():
@@ -638,6 +727,7 @@ def main():
         ('init',          init,          config.INIT_PARAMS,   (),                   "Create configuration file"),
         ('show',          show,          config.SHOW_PARAMS,   config.SITE_SUPPRESS, "Show user and experiment info from the APS schedule"),
         ('tag',           tag,           config.TAG_PARAMS,    config.SITE_SUPPRESS, "Update user info EPICS PVs with info from the APS schedule"),
+        ('tag-manual',    tag_manual,    config.TAG_PARAMS,    config.SITE_SUPPRESS, "Interactively pick a DM experiment and update user info EPICS PVs"),
         ('create',        create,        config.CREATE_PARAMS, config.SITE_SUPPRESS, "Create a DM experiment from the APS scheduling system"),
         ('create-manual', create_manual, config.MANUAL_PARAMS, config.SITE_SUPPRESS, "Create a DM experiment manually for commissioning runs"),
         ('delete',        delete,        config.CREATE_PARAMS, config.SITE_SUPPRESS, "Delete a DM experiment from Sojourner"),

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -511,6 +511,36 @@ def add_user(args):
     dm.add_users(exp_obj, username_list)
 
 
+def list_users(args):
+    """
+    Select a DM experiment and list all users currently granted access,
+    including those added from the proposal and any manually added users.
+    """
+    exp_name = _select_experiment(args, 'list users for')
+    if exp_name is None:
+        return
+
+    exp_obj = dm.get_experiment(exp_name)
+    if exp_obj is None:
+        log.error('DM experiment not found: %s' % exp_name)
+        return
+
+    username_list = exp_obj.get('experimentUsernameList', [])
+    if not username_list:
+        log.info('No users on experiment %s' % exp_name)
+        return
+
+    log.info('Users on %s:' % exp_name)
+    for uname in sorted(username_list):
+        user_obj = dm.get_user(uname)
+        if user_obj:
+            name  = dm.make_pretty_user_name(user_obj)
+            email = user_obj.get('email', '')
+            log.info('   %-12s  %-30s  %s' % (uname, name, email))
+        else:
+            log.info('   %s  (name not found)' % uname)
+
+
 def start_daq(args):
     """
     Select a DM experiment and start automated real-time file transfer (DAQ) to Sojourner.
@@ -737,6 +767,7 @@ def main():
         ('daq-stop',      stop_daq,      config.DAQ_PARAMS,    config.SITE_SUPPRESS, "Stop all running file transfers for the current experiment"),
         ('add-user',      add_user,      config.CREATE_PARAMS, config.SITE_SUPPRESS, "Add users to an existing DM experiment by badge number"),
         ('remove-user',   remove_user,   config.CREATE_PARAMS, config.SITE_SUPPRESS, "Remove users from an existing DM experiment by badge number"),
+        ('list-users',    list_users,    config.CREATE_PARAMS, config.SITE_SUPPRESS, "List all users with access to a DM experiment"),
     ]
 
     subparsers = parser.add_subparsers(title="Commands", metavar='')

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -612,8 +612,9 @@ def tag(args):
 
     if not proposals:
         log.error('No proposal found in the scheduling system for this run')
-        log.error("Create one with 'dmagic create' (or 'dmagic create-manual' for commissioning)")
-        log.error("then run 'dmagic tag-manual' to pick it and update the EPICS PVs")
+        log.error("If you have a scheduled proposal: run 'dmagic create' to create the DM experiment")
+        log.error("For commissioning or manual runs: run 'dmagic create-manual' instead")
+        log.error("Then run 'dmagic tag-manual' to select the experiment and update the EPICS PVs")
         return None
     try:
         log.error(proposals['message'])

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -209,6 +209,14 @@ def make_pretty_user_name(user_obj):
     return ' '.join(parts)
 
 
+def get_user(username):
+    """Return the DM user object for a username, or None on error."""
+    try:
+        return user_api.getUserByUsername(username)
+    except Exception:
+        return None
+
+
 def get_experiment(exp_name):
     """Return the DM experiment object for exp_name, or None if not found."""
     try:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -164,7 +164,7 @@ DM Experiment Management
 =========================
 
 The ``create``, ``create-manual``, ``delete``, ``email``, ``daq-start``, ``daq-stop``,
-``add-user``, and ``remove-user`` commands integrate with the APS Data Management (DM) system (Sojourner)
+``add-user``, ``remove-user``, and ``list-users`` commands integrate with the APS Data Management (DM) system (Sojourner)
 to manage experiment records, user data access via Globus, and automated file transfer. These
 commands require the ``[site]`` section of ``~/dmagic.conf`` to be correctly configured
 (see `Initialization`_ above). The ``daq-start`` and ``daq-stop`` commands additionally
@@ -474,6 +474,40 @@ Badge numbers can also be passed directly on the command line::
       --config FILE    File name of configuration (default: /home/beams/2BMB/dmagic.conf)
       --badges BADGES  Comma-separated badge number(s) to add/remove (e.g. 12345 or 12345,67890) (default: )
 
+dmagic list-users
+-----------------
+
+Lists all users currently granted access to a DM experiment, including users added from
+the scheduling proposal and any users added manually with ``dmagic add-user``. Lists all
+station experiments and prompts for selection, then prints each user's DM username, full
+name, and email address::
+
+    (dm) $ dmagic list-users
+    2026-03-06 10:00:00,000 - Found 10 DM experiment(s) for station 2BM:
+      [ 0] 2026-03-Li-1018528                   2026-03-11 to 2026-03-14  Investigation of ...
+      [ 1] 2026-03-Socha-1019623                2026-03-07 to 2026-03-09  Biomechanical ...
+      [ 2] 2026-03-Li-1012039                   2026-03-03 to 2026-03-05  Investigation of ...
+      ...
+
+    Select experiment to list users for [0-9] or 'q' to quit: 2
+    2026-03-06 10:00:05,000 - Users on 2026-03-Li-1012039:
+    2026-03-06 10:00:05,001 -    d49734        Pavel Shevchenko               pshevchenko@anl.gov
+    2026-03-06 10:00:05,002 -    d218262       Francesco DeCarlo              decarlo@anl.gov
+    2026-03-06 10:00:05,003 -    d226531       Tao Li                         tli@university.edu
+    2026-03-06 10:00:05,004 -    d67890        John Doe                       jdoe@lab.gov
+
+::
+
+    (dm) $ dmagic list-users -h
+    usage: dmagic list-users [-h] [--set SET] [--config FILE]
+
+    List all users with access to a DM experiment
+
+    options:
+      -h, --help     show this help message and exit
+      --set SET      Number of +/- days offset from today for past/future user groups (default: 0)
+      --config FILE  File name of configuration (default: /home/beams/2BMB/dmagic.conf)
+
 Command Reference
 =================
 
@@ -501,3 +535,4 @@ Command Reference
         daq-stop     Stop all running file transfers for the current experiment
         add-user     Add users to an existing DM experiment by badge number
         remove-user  Remove users from an existing DM experiment by badge number
+        list-users   List all users with access to a DM experiment

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -100,6 +100,65 @@ The information will be updated in the medm screen:
   :width: 400
   :alt: medm screen
 
+If no proposal is found in the scheduling system for the current run, ``dmagic tag``
+exits cleanly with a message::
+
+    2026-03-18 13:36:07,890 - No proposal found in the scheduling system for this run
+    2026-03-18 13:36:07,891 - Create one with 'dmagic create' (or 'dmagic create-manual' for commissioning)
+    2026-03-18 13:36:07,892 - then run 'dmagic tag-manual' to pick it and update the EPICS PVs
+
+dmagic tag-manual
+-----------------
+
+Interactively lists all DM experiments for the station — both scheduling-based and
+manually created, sorted newest first — and lets the operator choose which one to write
+to the EPICS PVs::
+
+    (dm) $ dmagic tag-manual
+    2026-03-18 13:34:52,000 - Today's date: 2026-03-18 13:34:52.000000
+    2026-03-18 13:34:52,500 - Found 3 DM experiment(s) for station 32ID:
+      [ 0] 2026-03-Nikitin-0                    2026-03-01 to 2026-03-15  Commissioning
+      [ 1] 32ID-TXM-CommissioningI              2025-03-04 to 2025-05-01  32-ID Operations Commissioning
+      [ 2] 2025-TXM-CommissioningI              2025-03-14 to 2025-05-01  32-ID Technical Comissioning
+
+    Select experiment to tag [0-2] or 'q' to quit: 0
+    2026-03-18 13:34:55,000 - Selected DM experiment: 2026-03-Nikitin-0
+    2026-03-18 13:34:55,100 - Using PI info parsed from DM experiment name (first name, institution, email, badge will be empty)
+    2026-03-18 13:34:55,200 - User/Experiment PV update
+    2026-03-18 13:34:55,201 - Updating pi_name EPICS PV with:
+    2026-03-18 13:34:55,202 - Updating pi_last_name EPICS PV with: Nikitin
+    2026-03-18 13:34:55,203 - Updating pi_affiliation EPICS PV with:
+    2026-03-18 13:34:55,204 - Updating pi_email EPICS PV with:
+    2026-03-18 13:34:55,205 - Updating pi_badge EPICS PV with:
+    2026-03-18 13:34:55,206 - Updating user_info_update_time EPICS PV with: 2026-03-18T13:34:55-06:00
+    2026-03-18 13:34:55,207 - Updating proposal_number EPICS PV with: 0
+    2026-03-18 13:34:55,208 - Updating proposal_title EPICS PV with: Commissioning
+    2026-03-18 13:34:55,209 - Updating experiment_date EPICS PV with: 2026-03
+
+For scheduling-based experiments (non-zero GUP), full PI info is fetched from the
+scheduling system automatically. This command is also useful when you need to switch
+the EPICS PVs to a different user group mid-run without touching the scheduling system.
+
+.. note::
+    For commissioning runs with no scheduling proposal, the typical workflow is:
+
+    1. ``dmagic create-manual`` — create the DM experiment
+    2. ``dmagic tag-manual`` — activate it in the EPICS PVs
+    3. ``dmagic email`` — notify users of their Globus data link (optional)
+    4. ``dmagic daq-start`` — start automated file transfer (optional)
+
+::
+
+    (dm) $ dmagic tag-manual -h
+    usage: dmagic tag-manual [-h] [--set SET] [--config FILE]
+
+    Interactively pick a DM experiment and update user info EPICS PVs
+
+    options:
+      -h, --help     show this help message and exit
+      --set SET      Number of +/- days offset from today for past/future user groups (default: 0)
+      --config FILE  File name of configuration (default: /home/beams/2BMB/dmagic.conf)
+
 DM Experiment Management
 =========================
 
@@ -431,6 +490,7 @@ Command Reference
         init         Create configuration file
         show         Show user and experiment info from the APS schedule
         tag          Update user info EPICS PVs with info from the APS schedule
+        tag-manual   Interactively pick a DM experiment and update user info EPICS PVs
         create       Create a DM experiment from the APS scheduling system
         create-manual
                      Create a DM experiment manually for commissioning runs

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -104,8 +104,9 @@ If no proposal is found in the scheduling system for the current run, ``dmagic t
 exits cleanly with a message::
 
     2026-03-18 13:36:07,890 - No proposal found in the scheduling system for this run
-    2026-03-18 13:36:07,891 - Create one with 'dmagic create' (or 'dmagic create-manual' for commissioning)
-    2026-03-18 13:36:07,892 - then run 'dmagic tag-manual' to pick it and update the EPICS PVs
+    2026-03-18 13:36:07,891 - If you have a scheduled proposal: run 'dmagic create' to create the DM experiment
+    2026-03-18 13:36:07,892 - For commissioning or manual runs: run 'dmagic create-manual' instead
+    2026-03-18 13:36:07,893 - Then run 'dmagic tag-manual' to select the experiment and update the EPICS PVs
 
 dmagic tag-manual
 -----------------

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     description = 'Data Management Magic Tools.',
     packages = find_packages(),
     package_data={'dmagic': ['*.txt']},
+    install_requires=['pyyaml'],
     entry_points={'console_scripts':['dmagic = dmagic.__main__:main'],},
     version = open('VERSION').read().strip(),
     zip_safe = False,


### PR DESCRIPTION
### Summary

- **Fix** `dmagic tag` crash (`IndexError`) when no scheduling proposal is found for the current date; improve guidance message pointing users to `--set` offset
- **Add** `dmagic tag-manual` command: interactively select a DM experiment and update EPICS PVs without requiring an active scheduling proposal
- **Add** `dmagic list-users` command: select a DM experiment and print all users currently granted access (DM username, full name, email), covering both proposal-seeded users and any manually added via `dmagic add-user`
- **Enhance** `dmagic show` output with additional fields already available in the scheduling REST API: proposal type (GUP/PUP), submission date, granted/scheduled shifts, and proprietary/mail-in flags

### Test plan

- [ ] Run `dmagic tag` with no active proposal (e.g. outside a run) and confirm it exits cleanly with a helpful message instead of crashing
- [ ] Run `dmagic tag-manual` and confirm it lists experiments, accepts a selection, and updates EPICS PVs correctly
- [ ] Run `dmagic list-users` on an experiment with both proposal users and a manually added user; confirm both appear in the output
- [ ] Run `dmagic show` during an active run and confirm the four new fields appear in the output
