### PR TITLE
Add upload, dual-DAQ, ESAF, new-users email, and config improvements  

### DIFF
--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -564,8 +564,10 @@ def list_users(args):
 
 def start_daq(args):
     """
-    Select a DM experiment and start automated real-time file transfer (DAQ) to Sojourner.
-    The DM system will monitor the analysis machine directory for new files and transfer them.
+    Select a DM experiment and start two automated real-time file transfers (DAQs) to Sojourner:
+      - raw data:           analysis_top_dir/<exp_name>      → DM data directory
+      - reconstructed data: analysis_top_dir/<exp_name>_rec  → DM analysis directory
+    The rec DAQ is skipped with a warning if the directory does not yet exist.
     """
     exp_name = _select_experiment(args, 'start DAQ for')
     if exp_name is None:
@@ -581,6 +583,21 @@ def stop_daq(args):
     if exp_name is None:
         return
     dm.stop_daq(exp_name)
+
+
+def upload(args):
+    """
+    Select a DM experiment and perform a one-shot upload of all existing files to Sojourner.
+    Use this when daq-start was not running while data was being collected.
+    Uploads from the same directories as daq-start:
+      - raw data:           analysis_top_dir/<exp_name>      → DM data directory
+      - reconstructed data: analysis_top_dir/<exp_name>_rec  → DM analysis directory
+    The rec upload is skipped with a warning if the directory does not exist.
+    """
+    exp_name = _select_experiment(args, 'upload data for')
+    if exp_name is None:
+        return
+    dm.upload(exp_name, args.analysis, args.analysis_top_dir)
 
 
 def _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date, esaf_number=''):
@@ -790,8 +807,9 @@ def main():
         ('create-manual', create_manual, config.MANUAL_PARAMS, config.SITE_SUPPRESS, "Create a DM experiment manually for commissioning runs"),
         ('delete',        delete,        config.CREATE_PARAMS, config.SITE_SUPPRESS, "Delete a DM experiment from Sojourner"),
         ('email',         email,         config.EMAIL_PARAMS,  config.SITE_SUPPRESS, "Send data-access email with Globus link to all users on the DM experiment"),
-        ('daq-start',     start_daq,     config.DAQ_PARAMS,    config.SITE_SUPPRESS, "Start automated real-time file transfer (DAQ) to Sojourner"),
-        ('daq-stop',      stop_daq,      config.DAQ_PARAMS,    config.SITE_SUPPRESS, "Stop all running file transfers for the current experiment"),
+        ('daq-start',     start_daq,     config.DAQ_PARAMS,    config.SITE_SUPPRESS, "Monitor experiment directories and sync new files to Sojourner in real time"),
+        ('daq-stop',      stop_daq,      config.DAQ_PARAMS,    config.SITE_SUPPRESS, "Stop real-time directory monitoring and file sync for the current experiment"),
+        ('upload',        upload,        config.DAQ_PARAMS,    config.SITE_SUPPRESS, "One-shot sync of all existing files to Sojourner (use when daq-start was not running)"),
         ('add-user',      add_user,      config.CREATE_PARAMS, config.SITE_SUPPRESS, "Add users to an existing DM experiment by badge number"),
         ('remove-user',   remove_user,   config.CREATE_PARAMS, config.SITE_SUPPRESS, "Remove users from an existing DM experiment by badge number"),
         ('list-users',    list_users,    config.CREATE_PARAMS, config.SITE_SUPPRESS, "List all users with access to a DM experiment"),
@@ -840,7 +858,7 @@ def main():
             write_sections = ('site',)
         elif cmd == 'create-manual':
             write_sections = ('manual', 'settings', 'site')
-        elif cmd in ('daq-start', 'daq-stop'):
+        elif cmd in ('daq-start', 'daq-stop', 'upload'):
             write_sections = ('local', 'settings', 'site')
         else:
             write_sections = ('settings', 'site')

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -98,6 +98,7 @@ def init_PVs(args):
     user_pvs['proposal_title'] = PV(tomoscan_prefix + 'ProposalTitle')
     user_pvs['user_info_update_time'] = PV(tomoscan_prefix + 'UserInfoUpdate')
     user_pvs['experiment_date'] = PV(tomoscan_prefix + 'ExperimentYearMonth')
+    user_pvs['esaf_number'] = PV(tomoscan_prefix + 'ESAFNumber')
     return user_pvs
 
 def init(args):
@@ -167,7 +168,9 @@ def show(args):
         log.info("\tPI affiliation: %s" % (pi_affiliation))
         log.info("\tPI e-mail: %s" % (pi_email))
         log.info("\tPI badge: %s" % (pi_badge))
+        esaf_number = proposal.get('experimentId') or 'N/A'
         log.info("\tProposal GUP: %s" % (proposal_id))
+        log.info("\tESAF number: %s" % esaf_number)
         log.info("\tProposal Title: %s" % (proposal_title))
         log.info("\tProposal type: %s" % prop_type)
         log.info("\tSubmitted: %s" % submitted)
@@ -580,16 +583,17 @@ def stop_daq(args):
     dm.stop_daq(exp_name)
 
 
-def _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date):
+def _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date, esaf_number=''):
     """Initialize EPICS PVs, verify connectivity, and write user/experiment fields.
 
     Parameters
     ----------
-    args         : CLI args (needs tomoscan_prefix, epics_conn_timeout)
-    pi           : dict with keys firstName, lastName, institution, email, badge
-    proposal_num : str — GUP number or manual identifier
+    args           : CLI args (needs tomoscan_prefix, epics_conn_timeout)
+    pi             : dict with keys firstName, lastName, institution, email, badge
+    proposal_num   : str — GUP number or manual identifier
     proposal_title : str
-    exp_date     : str — 'YYYY-MM'
+    exp_date       : str — 'YYYY-MM'
+    esaf_number    : str — ESAF number (empty string if not available)
 
     Returns True on success, False if the IOC is unreachable.
     """
@@ -634,6 +638,8 @@ def _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date):
     log.info('Updating proposal_title EPICS PV with: %s' % proposal_title)
     user_pvs['experiment_date'].put(exp_date)
     log.info('Updating experiment_date EPICS PV with: %s' % exp_date)
+    user_pvs['esaf_number'].put(str(esaf_number))
+    log.info('Updating esaf_number EPICS PV with: %s' % esaf_number)
     return True
 
 
@@ -682,8 +688,9 @@ def tag(args):
     proposal_title = str(scheduling.get_current_proposal_title(proposal))
     start_datetime = datetime.datetime.strptime(utils.fix_iso(proposal['startTime']), '%Y-%m-%dT%H:%M:%S%z')
     exp_date       = start_datetime.strftime('%Y-%m')
+    esaf_number    = str(proposal.get('experimentId') or '')
 
-    _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date)
+    _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date, esaf_number)
 
 
 def tag_manual(args):
@@ -740,12 +747,14 @@ def tag_manual(args):
 
     # For non-zero GUP numbers try to pull full PI info from the scheduling system
     pi = None
+    esaf_number = ''
     if gup_str.isdigit() and int(gup_str) != 0:
         try:
             auth     = authorize.basic(args.credentials)
             beamtime = scheduling.get_beamtime(gup_str, auth, args)
             if beamtime is not None:
                 pi = scheduling.get_current_pi(beamtime)
+                esaf_number = str(beamtime.get('experimentId') or '')
                 log.info('Retrieved full PI info from scheduling system for GUP %s' % gup_str)
         except Exception as e:
             log.warning('Could not retrieve PI info from scheduling system: %s' % str(e))
@@ -754,7 +763,7 @@ def tag_manual(args):
         log.warning('Using PI info parsed from DM experiment name (first name, institution, email, badge will be empty)')
         pi = {'firstName': '', 'lastName': pi_last, 'institution': '', 'email': '', 'badge': ''}
 
-    _update_tag_pvs(args, pi, gup_str, proposal_title, exp_date)
+    _update_tag_pvs(args, pi, gup_str, proposal_title, exp_date, esaf_number)
 
 
 def main():

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -406,6 +406,39 @@ def email(args):
     args.presentation_url = tomolog_utils.get_presentation_url(gup, args.tomolog_home)
 
     log.info('Sending e-mail to users on the DM experiment: %s' % args._exp_name)
+
+    # Determine which users need to be emailed
+    all_users      = set(dm.list_users_this_dm_exp(args) or [])
+    already_emailed = dm.get_emailed_users(args._exp_name)
+    new_users      = all_users - already_emailed
+
+    if already_emailed:
+        if new_users:
+            log.info('   %d user(s) already emailed previously, %d new user(s) added:'
+                     % (len(already_emailed), len(new_users)))
+            for u in sorted(new_users):
+                log.info('      %s' % u)
+            while True:
+                resp = input("Email [A]ll users / [N]ew users only / [C]ancel: ").strip().lower()
+                if resp in ('a', 'n', 'c'):
+                    break
+            if resp == 'c':
+                log.info('   Aborted.')
+                return
+            args._user_filter = list(new_users) if resp == 'n' else None
+        else:
+            log.info('   All %d user(s) have already been emailed previously.' % len(already_emailed))
+            while True:
+                resp = input("Re-send to [A]ll users / [C]ancel: ").strip().lower()
+                if resp in ('a', 'c'):
+                    break
+            if resp == 'c':
+                log.info('   Aborted.')
+                return
+            args._user_filter = None
+    else:
+        args._user_filter = None  # first time — email everyone
+
     args.msg = message.message(args)
     log.info('   Message preview:')
     log.info('   ' + '=' * 60)
@@ -418,18 +451,10 @@ def email(args):
             log.info('   %s' % line)
     log.info('   ' + '=' * 60)
 
-    users = dm.list_users_this_dm_exp(args)
-    if users:
-        emails = dm.make_user_email_list(users)
-        for contact in (args.primary_beamline_contact_email,
-                        args.secondary_beamline_contact_email):
-            if contact not in emails:
-                emails.append(contact)
-        log.info('   Recipients:')
-        for em in emails:
-            log.info('      %s' % em)
-
-    message.send_email(args)
+    sent = message.send_email(args)
+    if sent:
+        users_sent = set(args._user_filter) if args._user_filter is not None else all_users
+        dm.set_emailed_users(args._exp_name, already_emailed | users_sent)
 
 
 def _select_experiment(args, prompt_verb):

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -885,7 +885,7 @@ def main():
             write_sections = ('site',)
         elif cmd == 'create-manual':
             write_sections = ('manual', 'settings', 'site')
-        elif cmd in ('daq-start', 'daq-stop', 'upload'):
+        elif cmd in ('daq-start', 'daq-stop', 'upload', 'show'):
             write_sections = ('local', 'settings', 'site')
         else:
             write_sections = ('settings', 'site')

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -421,13 +421,13 @@ def email(args):
                 label = '{} ({})'.format(dm.make_pretty_user_name(user_obj), u) if user_obj else u
                 log.info('      %s' % label)
             while True:
-                resp = input("Email [A]ll users / [N]ew users only / [C]ancel: ").strip().lower()
-                if resp in ('a', 'n', 'c'):
+                resp = input("Email [A]ll users / [O]nly new users / [C]ancel: ").strip().lower()
+                if resp in ('a', 'o', 'c'):
                     break
             if resp == 'c':
                 log.info('   Aborted.')
                 return
-            args._user_filter = list(new_users) if resp == 'n' else None
+            args._user_filter = list(new_users) if resp == 'o' else None
         else:
             log.info('   All %d user(s) have already been emailed previously.' % len(already_emailed))
             while True:

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -417,7 +417,9 @@ def email(args):
             log.info('   %d user(s) already emailed previously, %d new user(s) added:'
                      % (len(already_emailed), len(new_users)))
             for u in sorted(new_users):
-                log.info('      %s' % u)
+                user_obj = dm.get_user(u)
+                label = '{} ({})'.format(dm.make_pretty_user_name(user_obj), u) if user_obj else u
+                log.info('      %s' % label)
             while True:
                 resp = input("Email [A]ll users / [N]ew users only / [C]ancel: ").strip().lower()
                 if resp in ('a', 'n', 'c'):

--- a/dmagic/config.py
+++ b/dmagic/config.py
@@ -54,10 +54,6 @@ SECTIONS['site'] = {
         'type': str,
         'default': 'message-2bm.txt',
         'help': 'Email message template file name sent to users'},
-    'globus-server-top-dir': {
-        'type': str,
-        'default': '/gdata/dm/2BM',
-        'help': 'Path from data storage root to the beamline top directory'},
     'globus-server-uuid': {
         'type': str,
         'default': '054a0877-97ca-4d80-947f-47ca522b173e',

--- a/dmagic/config.py
+++ b/dmagic/config.py
@@ -139,7 +139,7 @@ SECTIONS['local'] = {
     }
 
 INIT_PARAMS   = ('site',)
-SHOW_PARAMS   = ('settings',)
+SHOW_PARAMS   = ('settings', 'local')
 TAG_PARAMS    = ('settings',)
 CREATE_PARAMS = ('settings',)
 MANUAL_PARAMS = ('manual',)

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -217,6 +217,33 @@ def get_user(username):
         return None
 
 
+def get_emailed_users(exp_name):
+    """Return the set of DM usernames already emailed for this experiment.
+
+    Reads from DM experiment metadata key 'emailedUsers'. Returns an empty
+    set if the metadata has not been set yet or on any error.
+    """
+    try:
+        exp_obj = exp_api.getExperimentByName(exp_name)
+        stored = exp_obj.get('emailedUsers', '')
+        return set(u for u in stored.split(',') if u)
+    except Exception:
+        return set()
+
+
+def set_emailed_users(exp_name, username_set):
+    """Persist the set of emailed DM usernames as experiment metadata.
+
+    Stores under key 'emailedUsers' as a comma-separated string.
+    """
+    value = ','.join(sorted(username_set))
+    try:
+        exp_api.upsertExperimentMetadata('emailedUsers', value, exp_name)
+        log.info('   Updated emailed-users record for %s' % exp_name)
+    except Exception as e:
+        log.warning('   Could not save emailed-users metadata: %s' % str(e))
+
+
 def get_experiment(exp_name):
     """Return the DM experiment object for exp_name, or None if not found."""
     try:

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -290,37 +290,57 @@ def make_data_link(args):
     return link
 
 
-def start_daq(exp_name, analysis, analysis_top_dir):
-    """Start a DM DAQ for exp_name, watching analysis_top_dir/exp_name on the analysis machine.
+def _start_one_daq(exp_name, dm_dir_name, task_info, current_daqs):
+    """Start a single DAQ if not already running for (exp_name, dm_dir_name).
 
-    The DM system will monitor the directory for incoming files and transfer them automatically.
-    Returns True on success, False on error.
+    Returns True if already running or successfully started, False on error.
     """
-    analysis_dir = os.path.join(analysis_top_dir.rstrip('/'), exp_name)
-    dm_dir_name  = '@{:s}:{:s}'.format(analysis, analysis_dir)
+    for d in current_daqs:
+        if (d['experimentName'] == exp_name and d['status'] == 'running'
+                and d['dataDirectory'] == dm_dir_name):
+            log.warning('   DAQ already running for %s' % dm_dir_name)
+            return True
+    log.info('   Watching directory: %s' % dm_dir_name)
+    try:
+        daq_api.startDaq(exp_name, dm_dir_name, task_info)
+        log.info('   DAQ started successfully')
+        return True
+    except Exception as e:
+        log.error('   Could not start DAQ: %s' % str(e))
+        return False
 
-    log.info('Checking for already running DAQ for experiment %s' % exp_name)
+
+def start_daq(exp_name, analysis, analysis_top_dir):
+    """Start two DM DAQs for exp_name:
+      - raw data:          analysis_top_dir/<exp_name>      → DM data directory
+      - reconstructed data: analysis_top_dir/<exp_name>_rec → DM analysis directory
+
+    The rec DAQ is skipped with a warning if the directory does not yet exist.
+    Returns True if at least the raw DAQ started, False on error.
+    """
+    log.info('Checking for already running DAQs for experiment %s' % exp_name)
     try:
         current_daqs = daq_api.listDaqs()
     except Exception as e:
         log.error('   Could not list DAQs: %s' % str(e))
         return False
 
-    for d in current_daqs:
-        if (d['experimentName'] == exp_name and d['status'] == 'running'
-                and d['dataDirectory'] == dm_dir_name):
-            log.warning('   DAQ is already running for %s. Returning.' % exp_name)
-            return True
+    top = analysis_top_dir.rstrip('/')
 
-    log.info('Starting DAQ for experiment %s' % exp_name)
-    log.info('   Watching directory: %s' % dm_dir_name)
-    try:
-        daq_api.startDaq(exp_name, dm_dir_name)
-        log.info('   DAQ started successfully')
-        return True
-    except Exception as e:
-        log.error('   Could not start DAQ: %s' % str(e))
-        return False
+    # Raw data DAQ → DM data directory
+    raw_dir = '@{:s}:{:s}'.format(analysis, os.path.join(top, exp_name))
+    log.info('Starting raw data DAQ for experiment %s' % exp_name)
+    raw_ok = _start_one_daq(exp_name, raw_dir, {}, current_daqs)
+
+    # Reconstructed data DAQ → DM analysis directory
+    rec_dir = '@{:s}:{:s}'.format(analysis, os.path.join(top, exp_name + '_rec'))
+    log.info('Starting reconstructed data DAQ for experiment %s' % exp_name)
+    rec_ok = _start_one_daq(exp_name, rec_dir, {'useAnalysisDirectory': True}, current_daqs)
+    if not rec_ok:
+        log.warning('   Rec DAQ could not be started (directory may not exist yet)')
+        log.warning('   Run "dmagic daq-start" again once reconstruction begins')
+
+    return raw_ok
 
 
 def stop_daq(exp_name):
@@ -350,3 +370,46 @@ def stop_daq(exp_name):
     else:
         log.info('   Stopped %d DAQ(s) for experiment %s' % (count, exp_name))
     return True
+
+
+def upload(exp_name, analysis, analysis_top_dir):
+    """One-shot upload of raw and reconstructed data to the DM experiment.
+
+    Uploads files that exist at the time the command is issued (unlike DAQ,
+    which monitors for new files continuously). Use this when daq-start was
+    not running while data was being collected. Uses the same source directories
+    as daq-start:
+
+      - raw data:           analysis_top_dir/<exp_name>      → DM data directory
+      - reconstructed data: analysis_top_dir/<exp_name>_rec  → DM analysis directory
+
+    The rec upload is skipped with a warning if the directory does not exist.
+    Returns True if at least the raw upload started, False on error.
+    """
+    top = analysis_top_dir.rstrip('/')
+
+    raw_dir = '@{:s}:{:s}'.format(analysis, os.path.join(top, exp_name))
+    rec_dir = '@{:s}:{:s}'.format(analysis, os.path.join(top, exp_name + '_rec'))
+
+    # Raw data → DM data directory
+    log.info('Uploading raw data for experiment %s' % exp_name)
+    log.info('   Source: %s' % raw_dir)
+    raw_ok = False
+    try:
+        daq_api.upload(exp_name, raw_dir)
+        log.info('   Raw data upload started successfully')
+        raw_ok = True
+    except Exception as e:
+        log.error('   Could not start raw data upload: %s' % str(e))
+
+    # Reconstructed data → DM analysis directory
+    log.info('Uploading reconstructed data for experiment %s' % exp_name)
+    log.info('   Source: %s' % rec_dir)
+    try:
+        daq_api.upload(exp_name, rec_dir, {'useAnalysisDirectory': True})
+        log.info('   Reconstructed data upload started successfully')
+    except Exception as e:
+        log.warning('   Could not start reconstructed data upload: %s' % str(e))
+        log.warning('   (directory may not exist yet)')
+
+    return raw_ok

--- a/dmagic/message-2bm.txt
+++ b/dmagic/message-2bm.txt
@@ -15,12 +15,20 @@ It will be deleted permanently after that time.</strong></p>
 
 <p>Data link: %%DATA_LINK%%</p>
 
+<p><strong>Important:</strong> APS grants access to your data using the email address you provided
+during user registration. Your Globus account must be linked to that same email address.
+If it is not, please link it before proceeding:
+<ol type="a">
+  <li>Log into <a href="https://www.globus.org">globus.org</a> with your existing Globus account</li>
+  <li>Go to <strong>Settings &rarr; Account &rarr; Identities</strong> and click <strong>Link Another Identity</strong></li>
+  <li>Select your institution, or choose to link by email if your institution is not listed</li>
+  <li>Enter the email used for APS user registration and follow the verification steps</li>
+</ol>
+</p>
+
 <ol>
   <li>Login into Globus with your personal Globus credential</li>
-  <li>Login to the APS data management system using the same badge number/password combination
-      that you use to access the APS proposal system, but put a &ldquo;d&rdquo; in front of the badge number</li>
-  <li>If you forgot your password please contact the user office at
-      <a href="mailto:apsuser@anl.gov">apsuser@anl.gov</a></li>
+  <li>Login to the APS data management system using your Globus account when prompted</li>
   <li>Set an endpoint on your computer (see
       <a href="https://www.globus.org/globus-connect-personal">Globus EndPoint</a>)</li>
   <li>Raw files are in the <strong>data</strong> folder and reconstructed files in the <strong>analysis</strong> folder,

--- a/dmagic/message.py
+++ b/dmagic/message.py
@@ -152,10 +152,15 @@ def send_email(args):
         emails = [args.secondary_beamline_contact_email]
         log.info('   *** TEST mode: sending only to secondary beamline contact')
     else:
-        users = dm.list_users_this_dm_exp(args)
-        if users is None:
-            log.error('   Cannot send email: no DM experiment found. Have you run "dmagic create" yet?')
-            return False
+        # Use pre-filtered user list if set by the caller (e.g. new-users-only mode)
+        user_filter = getattr(args, '_user_filter', None)
+        if user_filter is not None:
+            users = user_filter
+        else:
+            users = dm.list_users_this_dm_exp(args)
+            if users is None:
+                log.error('   Cannot send email: no DM experiment found. Have you run "dmagic create" yet?')
+                return False
 
         emails = dm.make_user_email_list(users)
         if not emails:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -337,8 +337,10 @@ mid-experiment after the initial notification has already gone out.
     ...
     Select experiment to email [0-10] or 'q' to quit: 0
     2026-03-04 10:00:00,000 -    3 user(s) already emailed previously, 1 new user(s) added:
-    2026-03-04 10:00:00,100 -       newuser
-    Email [A]ll users / [N]ew users only / [C]ancel: N
+    2026-03-04 10:00:00,100 -       Sarah D. Boyer (d313356)
+    Email [A]ll users / [O]nly new users / [C]ancel: O
+    Send email to users?
+       *** Yes / No / Test (Y/N/T): Y
     2026-03-04 10:00:05,000 -    Sending informational message to newuser@university.edu
     2026-03-04 10:00:05,100 -    Sending informational message to pshevchenko@anl.gov
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -337,9 +337,18 @@ experiment. Lists all station experiments and prompts for selection. Requires th
 dmagic daq-start
 ----------------
 
-Starts automated real-time file transfer (DAQ) to Sojourner. The DM system monitors
-the configured directory on the analysis machine for new files and transfers them
-continuously. Lists all station experiments and prompts for selection::
+Starts real-time directory monitoring and syncs new files to Sojourner continuously.
+Only files created or modified **after** this command is issued are transferred.
+Two DAQ processes are started for each experiment:
+
+- **Raw data**: ``{analysis-top-dir}/{exp-name}`` on the analysis machine → DM ``data/`` directory
+- **Reconstructed data**: ``{analysis-top-dir}/{exp-name}_rec`` → DM ``analysis/`` directory
+
+The rec DAQ is skipped with a warning if the ``_rec`` directory does not yet exist —
+run ``dmagic daq-start`` again once reconstruction begins to pick it up.
+If a DAQ is already running for a given directory it is left untouched.
+
+::
 
     (dm) $ dmagic daq-start
     2026-03-04 09:10:00,000 - Found 11 DM experiment(s) for station 2BM:
@@ -348,16 +357,17 @@ continuously. Lists all station experiments and prompts for selection::
       ...
 
     Select experiment to start DAQ for [0-10] or 'q' to quit: 1
-    2026-03-04 09:10:05,000 - Checking for already running DAQ for experiment 2026-03-Li-1012039
-    2026-03-04 09:10:05,100 - Starting DAQ for experiment 2026-03-Li-1012039
-    2026-03-04 09:10:05,101 -    Watching directory: @tomodata3:/data3/2BM/2026-03-Li-1012039
-    2026-03-04 09:10:06,000 -    DAQ started successfully
+    2026-03-04 09:10:05,000 - Starting raw data DAQ for experiment 2026-03-Li-1012039
+    2026-03-04 09:10:05,100 -    Watching directory: @tomodata3:/data3/2BM/2026-03-Li-1012039
+    2026-03-04 09:10:05,200 -    DAQ started successfully
+    2026-03-04 09:10:05,300 - Starting reconstructed data DAQ for experiment 2026-03-Li-1012039
+    2026-03-04 09:10:05,400 -    Watching directory: @tomodata3:/data3/2BM/2026-03-Li-1012039_rec
+    2026-03-04 09:10:05,500 -    DAQ started successfully
 
 The ``analysis`` and ``analysis-top-dir`` settings in ``~/dmagic.conf`` control which
-host and directory the DM agent monitors. The monitored path is
-``{analysis-top-dir}/{experiment-name}`` on the ``analysis`` host. For best performance,
-point ``analysis`` at the storage node (e.g. ``tomodata3``) that physically hosts the
-data, rather than a compute node that accesses it via NFS.
+host and directories are monitored. For best performance, point ``analysis`` at the
+storage node (e.g. ``tomodata3``) that physically hosts the data rather than a compute
+node that accesses it via NFS.
 
 ::
 
@@ -365,7 +375,7 @@ data, rather than a compute node that accesses it via NFS.
     usage: dmagic daq-start [-h] [--analysis ANALYSIS] [--analysis-top-dir ANALYSIS_TOP_DIR]
                             [--config FILE]
 
-    Start automated real-time file transfer (DAQ) to Sojourner
+    Monitor experiment directories and sync new files to Sojourner in real time
 
     options:
       -h, --help            show this help message and exit
@@ -377,8 +387,7 @@ data, rather than a compute node that accesses it via NFS.
 dmagic daq-stop
 ---------------
 
-Stops all running DAQs for the selected experiment. Lists all station experiments and
-prompts for selection::
+Stops all running DAQ processes (both raw and rec) for the selected experiment::
 
     (dm) $ dmagic daq-stop
     2026-03-04 18:00:00,000 - Found 11 DM experiment(s) for station 2BM:
@@ -389,7 +398,8 @@ prompts for selection::
     Select experiment to stop DAQ for [0-10] or 'q' to quit: 1
     2026-03-04 18:00:05,000 - Stopping all DM DAQs for experiment 2026-03-Li-1012039
     2026-03-04 18:00:05,100 -    Found running DAQ. Stopping now.
-    2026-03-04 18:00:06,000 -    Stopped 1 DAQ(s) for experiment 2026-03-Li-1012039
+    2026-03-04 18:00:05,200 -    Found running DAQ. Stopping now.
+    2026-03-04 18:00:06,000 -    Stopped 2 DAQ(s) for experiment 2026-03-Li-1012039
 
 ::
 
@@ -397,7 +407,52 @@ prompts for selection::
     usage: dmagic daq-stop [-h] [--analysis ANALYSIS] [--analysis-top-dir ANALYSIS_TOP_DIR]
                            [--config FILE]
 
-    Stop all running file transfers for the current experiment
+    Stop real-time directory monitoring and file sync for the current experiment
+
+    options:
+      -h, --help            show this help message and exit
+      --analysis ANALYSIS   Hostname of the data analysis computer (default: tomodata3)
+      --analysis-top-dir ANALYSIS_TOP_DIR
+                            Top-level data directory on the analysis computer (default: /data3/2BM/)
+      --config FILE         File name of configuration (default: /home/beams/2BMB/dmagic.conf)
+
+dmagic upload
+-------------
+
+Performs a one-shot sync of **all files that currently exist** in the experiment
+directories to Sojourner. Use this when ``dmagic daq-start`` was not running while
+data was being collected. Unlike ``daq-start``, which monitors for new files
+continuously, ``upload`` transfers everything present at the moment the command is
+issued and then exits.
+
+The same two directories as ``daq-start`` are used:
+
+- **Raw data**: ``{analysis-top-dir}/{exp-name}`` → DM ``data/`` directory
+- **Reconstructed data**: ``{analysis-top-dir}/{exp-name}_rec`` → DM ``analysis/`` directory
+
+The rec upload is skipped with a warning if the ``_rec`` directory does not exist::
+
+    (dm) $ dmagic upload
+    2026-03-04 10:00:00,000 - Found 11 DM experiment(s) for station 2BM:
+      [ 0] 2026-03-Li-1018528                   2026-03-11 to 2026-03-14  Investigation of ...
+      [ 1] 2026-03-Li-1012039                   2026-03-03 to 2026-03-05  Investigation of ...
+      ...
+
+    Select experiment to upload data for [0-10] or 'q' to quit: 1
+    2026-03-04 10:00:05,000 - Uploading raw data for experiment 2026-03-Li-1012039
+    2026-03-04 10:00:05,100 -    Source: @tomodata3:/data3/2BM/2026-03-Li-1012039
+    2026-03-04 10:00:05,200 -    Raw data upload started successfully
+    2026-03-04 10:00:05,300 - Uploading reconstructed data for experiment 2026-03-Li-1012039
+    2026-03-04 10:00:05,400 -    Source: @tomodata3:/data3/2BM/2026-03-Li-1012039_rec
+    2026-03-04 10:00:05,500 -    Reconstructed data upload started successfully
+
+::
+
+    (dm) $ dmagic upload -h
+    usage: dmagic upload [-h] [--analysis ANALYSIS] [--analysis-top-dir ANALYSIS_TOP_DIR]
+                         [--config FILE]
+
+    One-shot sync of all existing files to Sojourner (use when daq-start was not running)
 
     options:
       -h, --help            show this help message and exit
@@ -538,8 +593,10 @@ Command Reference
                      Create a DM experiment manually for commissioning runs
         delete       Delete a DM experiment from Sojourner
         email        Send data-access email with Globus link to all users on the DM experiment
-        daq-start    Start automated real-time file transfer (DAQ) to Sojourner
-        daq-stop     Stop all running file transfers for the current experiment
+        daq-start    Monitor experiment directories and sync new files to Sojourner in real time
+        daq-stop     Stop real-time directory monitoring and file sync for the current experiment
+        upload       One-shot sync of all existing files to Sojourner (use when daq-start was not running)
         add-user     Add users to an existing DM experiment by badge number
         remove-user  Remove users from an existing DM experiment by badge number
+        upload       One-shot sync of all existing files to Sojourner (use when daq-start was not running)
         list-users   List all users with access to a DM experiment

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -304,9 +304,16 @@ To delete a manually created experiment directly by name (without going through 
 dmagic email
 ------------
 
-Sends a data-access notification email with a Globus link to all users on a DM
+Sends a data-access notification email with a Globus link to users on a DM
 experiment. Lists all station experiments and prompts for selection. Requires that
-``dmagic create`` or ``dmagic create-manual`` has been run first::
+``dmagic create`` or ``dmagic create-manual`` has been run first.
+
+The command tracks which users have already received the email (stored as DM experiment
+metadata). If new users were added to the experiment since the last email was sent, it
+offers to email only the new users or all users. This is useful when users are added
+mid-experiment after the initial notification has already gone out.
+
+**First-time send** (no previous email recorded)::
 
     (dm) $ dmagic email
     2026-03-04 09:05:00,000 - Found 11 DM experiment(s) for station 2BM:
@@ -317,18 +324,40 @@ experiment. Lists all station experiments and prompts for selection. Requires th
     Select experiment to email [0-10] or 'q' to quit: 0
     2026-03-04 09:05:05,000 - Sending e-mail to users on the DM experiment: 2026-03-Li-1018528
     2026-03-04 09:05:05,100 -    Message to users:
-    2026-03-04 09:05:05,200 -    *** All, ...
+    2026-03-04 09:05:05,200 -    *** Subject: Important information for APS experiment ...
+    ...
     Send email to users?
-       *** Yes or No (Y/N): Y
+       *** Yes / No / Test (Y/N/T): Y
     2026-03-04 09:05:06,000 -    Sending informational message to user1@university.edu
     2026-03-04 09:05:06,100 -    Sending informational message to pshevchenko@anl.gov
+
+**Re-send when new users were added**::
+
+    (dm) $ dmagic email
+    ...
+    Select experiment to email [0-10] or 'q' to quit: 0
+    2026-03-04 10:00:00,000 -    3 user(s) already emailed previously, 1 new user(s) added:
+    2026-03-04 10:00:00,100 -       newuser
+    Email [A]ll users / [N]ew users only / [C]ancel: N
+    2026-03-04 10:00:05,000 -    Sending informational message to newuser@university.edu
+    2026-03-04 10:00:05,100 -    Sending informational message to pshevchenko@anl.gov
+
+**Re-send when all users already emailed**::
+
+    (dm) $ dmagic email
+    ...
+    Select experiment to email [0-10] or 'q' to quit: 0
+    2026-03-04 10:00:00,000 -    All 4 user(s) have already been emailed previously.
+    Re-send to [A]ll users / [C]ancel: A
+    2026-03-04 10:00:05,000 -    Sending informational message to user1@university.edu
+    ...
 
 ::
 
     (dm) $ dmagic email -h
     usage: dmagic email [-h] [--config FILE]
 
-    Send data-access email with Globus link to all users on the DM experiment
+    Send data-access email with Globus link to users on the DM experiment
 
     options:
       -h, --help     show this help message and exit

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -64,13 +64,18 @@ Queries the APS scheduling REST API to display the currently active experiment::
     2026-03-04 09:00:00,703 -   PI e-mail: wchen@purdue.edu
     2026-03-04 09:00:00,704 -   PI badge: 226531
     2026-03-04 09:00:00,705 -   Proposal GUP: 66310
-    2026-03-04 09:00:00,706 -   Proposal Title: In-situ visualization of ...
-    2026-03-04 09:00:00,707 -   Start date: 2026_03_03
-    2026-03-04 09:00:00,708 -   Start time: 2026-03-03 08:00:00-06:00
-    2026-03-04 09:00:00,709 -   End Time: 2026-03-05 08:00:00-06:00
-    2026-03-04 09:00:00,710 -   User email address:
-    2026-03-04 09:00:00,711 -        user1@university.edu
-    2026-03-04 09:00:00,712 -        user2@lab.gov
+    2026-03-04 09:00:00,706 -   ESAF number: 289884
+    2026-03-04 09:00:00,707 -   Proposal Title: In-situ visualization of ...
+    2026-03-04 09:00:00,708 -   Proposal type: GUP
+    2026-03-04 09:00:00,709 -   Submitted: 2025-09-15
+    2026-03-04 09:00:00,710 -   Granted shifts: 6  (scheduled: 6)
+    2026-03-04 09:00:00,711 -   Proprietary: N  |  Mail-in: N
+    2026-03-04 09:00:00,712 -   Start date: 2026_03_03
+    2026-03-04 09:00:00,713 -   Start time: 2026-03-03 08:00:00-06:00
+    2026-03-04 09:00:00,714 -   End Time: 2026-03-05 08:00:00-06:00
+    2026-03-04 09:00:00,715 -   User email address:
+    2026-03-04 09:00:00,716 -        user1@university.edu
+    2026-03-04 09:00:00,717 -        user2@lab.gov
 
 Use ``--set N`` to offset the date (negative for past, positive for future)::
 
@@ -93,6 +98,7 @@ Fetches the same scheduling data and writes it to EPICS PVs on the TomoScan IOC:
     2026-03-04 09:00:01,007 - Updating proposal_number EPICS PV with: 66310
     2026-03-04 09:00:01,008 - Updating proposal_title EPICS PV with: In-situ visualization of ...
     2026-03-04 09:00:01,009 - Updating experiment_date EPICS PV with: 2026-03
+    2026-03-04 09:00:01,010 - Updating esaf_number EPICS PV with: 289884
 
 The information will be updated in the medm screen:
 
@@ -135,6 +141,7 @@ to the EPICS PVs::
     2026-03-18 13:34:55,207 - Updating proposal_number EPICS PV with: 0
     2026-03-18 13:34:55,208 - Updating proposal_title EPICS PV with: Commissioning
     2026-03-18 13:34:55,209 - Updating experiment_date EPICS PV with: 2026-03
+    2026-03-18 13:34:55,210 - Updating esaf_number EPICS PV with:
 
 For scheduling-based experiments (non-zero GUP), full PI info is fetched from the
 scheduling system automatically. This command is also useful when you need to switch

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -26,7 +26,6 @@ beamline before using any other commands::
     credentials = /home/beams/2BMB/.scheduling_credentials
     experiment-type = 2BM
     globus-message-file = message-2bm.txt
-    globus-server-top-dir = /gdata/dm/2BM
     globus-server-uuid = 054a0877-97ca-4d80-947f-47ca522b173e
     primary-beamline-contact-badge = 218262
     primary-beamline-contact-email = pshevchenko@anl.gov


### PR DESCRIPTION
## Summary      

  - **`dmagic upload`**: new command to sync raw and reconstructed data to the Globus endpoint
  - **Dual-DAQ start**: `dmagic daq-start` now syncs both raw and rec directories
  - **ESAF number**: surfaced in `dmagic show` and `dmagic tag`
  - **New-users-only email**: `dmagic email` can now target only new users; shows name in
  new-user list
  - **Local settings**: `dmagic show` now displays local config and supports save-back
  - **Globus authentication**: `message-2bm.txt` updated to replace deprecated badge
  number/password
    login with Globus account login; added step-by-step instructions for users to link their
  APS
    registration email to their Globus account
  - **Bug fixes**:
    - Fix ambiguous prompt letter in `dmagic email` new-users flow
    - Remove unused `globus-server-top-dir` config parameter

  ## Test plan

  - [ ] Run `dmagic show` and verify ESAF number and local settings appear
  - [ ] Run `dmagic upload` and confirm data syncs to Globus endpoint
  - [ ] Run `dmagic daq-start` and verify both raw and rec directories are synced
  - [ ] Run `dmagic email` and verify new-users-only flow and name display
  - [ ] Send test email and verify updated Globus auth instructions render correctly in email
  client
  - [ ] Confirm `globus-server-top-dir` removal causes no regressions