### PR TITLE
Add ESAF user list to dmagic create, show, email, and list-users

### DIFF
--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -182,6 +182,12 @@ def show(args):
         log.info("\tUser email address: ")
         for ue in proposal_user_emails:
             log.info("\t\t %s" % (ue))
+        if esaf_number and esaf_number != 'N/A':
+            esaf_users = dm.get_esaf_users(esaf_number)
+            if esaf_users:
+                log.esaf('\tESAF %s users (not in proposal):' % esaf_number)
+                for u in sorted(esaf_users):
+                    log.esaf('\t\t %s' % u)
     else:
         time_now = datetime.datetime.now().astimezone() + dt.timedelta(args.set)
         log.warning('No proposal run on %s during %s' % (time_now, run))
@@ -254,17 +260,24 @@ def create(args):
     args.pi_badge       = bt['pi_badge']
     args.gup_number     = bt['gup_number']
     args.gup_title      = bt['gup_title']
+    args.esaf_number    = bt.get('esaf_number', '')
 
-    user_list = dm.make_dm_username_list(args)
-    exp_name  = dm.make_experiment_name(args)
-    if user_list is None:
+    gup_users, esaf_users = dm.make_dm_username_list(args)
+    exp_name = dm.make_experiment_name(args)
+    if gup_users is None:
         log.warning("GUP %s not found in the scheduling system." % args.gup_number)
         log.warning("Experiment '%s' will be created but no users will be added." % exp_name)
         log.info("To add a user afterwards run: dmagic add-user --badge <badge#>")
-        user_list = set()
+        args._user_list = set()
     else:
-        log.info('Adding users from the current proposal to the DM experiment.')
-    args._user_list = user_list
+        log.info('Users from proposal (GUP %s):' % args.gup_number)
+        for u in sorted(gup_users):
+            log.info('   %s' % u)
+        if esaf_users:
+            log.esaf('Users from ESAF %s (not in proposal):' % args.esaf_number)
+            for u in sorted(esaf_users):
+                log.esaf('   %s' % u)
+        args._user_list = gup_users | esaf_users
     _finish_create(args, exp_name)
 
 

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -11,17 +11,40 @@ __copyright__ = "Copyright (c) 2020, UChicago Argonne, LLC."
 __docformat__ = 'restructuredtext en'
 
 try:
-    from dm import ExperimentDsApi, UserDsApi, ExperimentDaqApi
+    from dm import ExperimentDsApi, UserDsApi, ExperimentDaqApi, EsafApsDbApi
     from dm.common.exceptions.objectAlreadyExists import ObjectAlreadyExists
     exp_api  = ExperimentDsApi()
     user_api = UserDsApi()
     daq_api  = ExperimentDaqApi()
+    esaf_api = EsafApsDbApi()
     oee      = ObjectAlreadyExists
     _DM_AVAILABLE = True
 except ImportError:
-    exp_api = user_api = daq_api = oee = None
+    exp_api = user_api = daq_api = esaf_api = oee = None
     _DM_AVAILABLE = False
     log.warning('DM SDK not available: create, delete, email, add-user, remove-user, daq-start, daq-stop commands will not work')
+
+
+def get_esaf_users(esaf_id):
+    """Return set of 'd+badge' strings for users listed in the ESAF.
+
+    Uses EsafApsDbApi.getStationEsafById() with the station name from the
+    DM_STATION_NAME environment variable (default '2BM').
+    Returns an empty set if esaf_id is empty, DM is unavailable, or the
+    call fails (e.g. session expired or access denied).
+    """
+    if not esaf_id or not _DM_AVAILABLE:
+        return set()
+    try:
+        station = os.environ.get('DM_STATION_NAME', '2BM')
+        esaf = esaf_api.getStationEsafById(station, int(esaf_id))
+        users = esaf.get('experimentUsers', [])
+        badges = {'d' + str(u['badge']) for u in users if u.get('badge')}
+        log.info('   Found %d user(s) in ESAF %s' % (len(badges), esaf_id))
+        return badges
+    except Exception as e:
+        log.warning('Could not retrieve ESAF users for ESAF %s: %s' % (esaf_id, str(e)))
+        return set()
 
 
 def make_experiment_name(args):
@@ -35,27 +58,32 @@ def make_experiment_name(args):
 
 
 def make_dm_username_list(args):
-    """Make a list of DM usernames 'd+badge#' from the current proposal (GUP number).
+    """Make DM username sets from the proposal (GUP) and ESAF user lists.
 
-    Returns None if the beamtime cannot be found in the scheduling system.
+    Returns (gup_set, esaf_set) where:
+      gup_set  — 'd+badge' strings from proposal experimenters + beamline contacts
+      esaf_set — 'd+badge' strings from ESAF experimenters NOT already in gup_set
+    Returns (None, set()) if the beamtime cannot be found in the scheduling system.
     """
     log.info('Making a list of DM system usernames from target proposal')
     auth = authorize.basic(args.credentials)
     if auth is None:
-        return None
+        return None, set()
     target_prop = scheduling.get_beamtime(str(args.gup_number), auth, args)
     if target_prop is None:
-        return None
+        return None, set()
     users = target_prop['beamtime']['proposal']['experimenters']
     log.info('   Adding the primary beamline contact')
-    user_ids = {'d' + str(args.primary_beamline_contact_badge)}
+    gup_set = {'d' + str(args.primary_beamline_contact_badge)}
     log.info('   Adding the secondary beamline contact')
-    user_ids.add('d' + str(args.secondary_beamline_contact_badge))
+    gup_set.add('d' + str(args.secondary_beamline_contact_badge))
     for u in users:
-        log.info('   Adding user {0}, {1}, badge {2}'.format(
+        log.info('   Adding GUP user {0}, {1}, badge {2}'.format(
                     u['lastName'], u['firstName'], u['badge']))
-        user_ids.add('d' + str(u['badge']))
-    return user_ids
+        gup_set.add('d' + str(u['badge']))
+    esaf_number = getattr(args, 'esaf_number', '') or ''
+    esaf_set = get_esaf_users(esaf_number) - gup_set
+    return gup_set, esaf_set
 
 
 def make_username_list(args):

--- a/dmagic/log.py
+++ b/dmagic/log.py
@@ -64,6 +64,9 @@ def error(msg):
 def warning(msg):
     logger.warning(msg)
 
+def esaf(msg):
+    logger.info('\033[96m' + msg + '\033[0m')
+
 def setup_custom_logger(lfname, stream_to_console=True):
     fHandler = logging.FileHandler(lfname)
     logger.setLevel(logging.DEBUG)
@@ -87,6 +90,8 @@ class ColoredLogFormatter(logging.Formatter):
     
     
     def formatMessage(self,record):
+        if record.message.startswith('\033['):
+            return super().formatMessage(record)
         if record.levelname=='INFO':
             record.message = self.__GREEN + record.message + self.__ENDC
         elif record.levelname == 'WARNING':

--- a/dmagic/message.py
+++ b/dmagic/message.py
@@ -172,13 +172,19 @@ def send_email(args):
                 emails.append(contact)
 
     s = smtplib.SMTP('mailhost.anl.gov')
+    any_sent = False
     for em in emails:
         if args.msg['To'] is None:
             args.msg['To'] = em
         else:
             args.msg.replace_header('To', em)
         log.info('   Sending informational message to {:s}'.format(em))
-        s.send_message(args.msg)
+        try:
+            s.send_message(args.msg)
+            any_sent = True
+        except smtplib.SMTPRecipientsRefused as e:
+            for addr, (code, msg) in e.recipients.items():
+                log.warning('   Skipping {:s}: {:d} {:s}'.format(addr, code, msg.decode()))
     s.quit()
 
-    return True
+    return any_sent

--- a/dmagic/scheduling.py
+++ b/dmagic/scheduling.py
@@ -216,6 +216,7 @@ def list_beamtimes(auth, args):
             'start_time':     item['startTime'],
             'end_time':       item['endTime'],
             'run_name':       run,
+            'esaf_number':    str(item.get('experimentId') or ''),
         })
 
     return beamtimes


### PR DESCRIPTION
### Summary

- **`dmagic create`** now adds the union of GUP proposal users and ESAF
  users to the DM experiment, so all personnel authorized for the beamtime
  can download their data from DM without any manual step.
  GUP users are logged in green; ESAF-only users in cyan.

- **`dmagic show`** now queries the ESAF and displays any users listed
  in the ESAF but not in the proposal, printed in cyan after the proposal
  user list.

- **`dmagic email`** and **`dmagic list-users`** automatically benefit
  from the union: since `create` now adds all users to the DM experiment,
  both commands operate on the full combined list with no changes required.

- **`dmagic email`** crash fix: gracefully handles SMTP rejection of a
  single recipient address instead of aborting the entire send.

### Implementation details

- `scheduling.py` — `list_beamtimes()` now returns `esaf_number`
  (from `experimentId` in the activity record) alongside existing fields.

- `dm.py` — adds `EsafApsDbApi` import and `get_esaf_users(esaf_id)`,
  which calls `getStationEsafById(DM_STATION_NAME, esaf_id)`. Falls back
  to an empty set on any error (expired session, no ESAF number, DM
  unavailable). `make_dm_username_list()` return type changed from a
  single `set` to a `(gup_set, esaf_set)` tuple.

- `log.py` — adds `log.esaf(msg)` printing in cyan (`\033[96m`);
  updates `ColoredLogFormatter` to skip the green wrapper for
  pre-colored messages.

- `__main__.py` — `create()` and `show()` wired to use both sets and
  colored logging.

### Notes

- ESAF access requires `EsafApsDbApi` with `user2bm` credentials
  (granted by DM support via `getStationEsafById`).
- Experiments created before this change only have GUP users in DM;
  use `dmagic add-user` to add ESAF-only users to existing experiments.

## Test plan

- [ ] `dmagic show` on arcturus: GUP user emails in green, ESAF-only
  users in cyan after the proposal list
- [ ] `dmagic create`: confirm DM experiment contains the union of GUP
  and ESAF users via `dmagic list-users`
- [ ] `dmagic create` with a beamtime that has no ESAF number: confirm
  no error, no cyan output
- [ ] `dmagic show` on a dev machine without DM SDK: confirm no import
  error
