### PR TITLE
GUP + ESAF user union

### DIFF
--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -171,6 +171,10 @@ def show(args):
         esaf_number = proposal.get('experimentId') or 'N/A'
         log.info("\tProposal GUP: %s" % (proposal_id))
         log.info("\tESAF number: %s" % esaf_number)
+        if esaf_number and esaf_number != 'N/A':
+            esaf_doi = dm.get_esaf_doi(esaf_number)
+            if esaf_doi:
+                log.info("\tESAF DOI: %s" % esaf_doi)
         log.info("\tProposal Title: %s" % (proposal_title))
         log.info("\tProposal type: %s" % prop_type)
         log.info("\tSubmitted: %s" % submitted)

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -703,11 +703,10 @@ def _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date, esaf_numbe
     user_pvs['esaf_number'].put(str(esaf_number))
     log.info('Updating esaf_number EPICS PV with: %s' % esaf_number)
     try:
-        user_pvs['esaf_doi'].put(str(esaf_doi or ''))
+        user_pvs['esaf_doi'].put(str(esaf_doi or '').encode('utf-8'))
         log.info('Updating esaf_doi EPICS PV with: %s' % esaf_doi)
     except Exception as e:
         log.warning('Could not update esaf_doi EPICS PV: %s' % str(e))
-        log.warning('   ESAFDOINumber PV must be a char waveform (FTVL=CHAR, NELM>=80) to hold a full URL')
     return True
 
 

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -702,8 +702,12 @@ def _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date, esaf_numbe
     log.info('Updating experiment_date EPICS PV with: %s' % exp_date)
     user_pvs['esaf_number'].put(str(esaf_number))
     log.info('Updating esaf_number EPICS PV with: %s' % esaf_number)
-    user_pvs['esaf_doi'].put(str(esaf_doi or ''))
-    log.info('Updating esaf_doi EPICS PV with: %s' % esaf_doi)
+    try:
+        user_pvs['esaf_doi'].put(str(esaf_doi or ''))
+        log.info('Updating esaf_doi EPICS PV with: %s' % esaf_doi)
+    except Exception as e:
+        log.warning('Could not update esaf_doi EPICS PV: %s' % str(e))
+        log.warning('   ESAFDOINumber PV must be a char waveform (FTVL=CHAR, NELM>=80) to hold a full URL')
     return True
 
 

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -99,6 +99,7 @@ def init_PVs(args):
     user_pvs['user_info_update_time'] = PV(tomoscan_prefix + 'UserInfoUpdate')
     user_pvs['experiment_date'] = PV(tomoscan_prefix + 'ExperimentYearMonth')
     user_pvs['esaf_number'] = PV(tomoscan_prefix + 'ESAFNumber')
+    user_pvs['esaf_doi']    = PV(tomoscan_prefix + 'ESAFDOINumber')
     return user_pvs
 
 def init(args):
@@ -644,7 +645,7 @@ def upload(args):
     dm.upload(exp_name, args.analysis, args.analysis_top_dir)
 
 
-def _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date, esaf_number=''):
+def _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date, esaf_number='', esaf_doi=''):
     """Initialize EPICS PVs, verify connectivity, and write user/experiment fields.
 
     Parameters
@@ -701,6 +702,8 @@ def _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date, esaf_numbe
     log.info('Updating experiment_date EPICS PV with: %s' % exp_date)
     user_pvs['esaf_number'].put(str(esaf_number))
     log.info('Updating esaf_number EPICS PV with: %s' % esaf_number)
+    user_pvs['esaf_doi'].put(str(esaf_doi or ''))
+    log.info('Updating esaf_doi EPICS PV with: %s' % esaf_doi)
     return True
 
 
@@ -750,8 +753,9 @@ def tag(args):
     start_datetime = datetime.datetime.strptime(utils.fix_iso(proposal['startTime']), '%Y-%m-%dT%H:%M:%S%z')
     exp_date       = start_datetime.strftime('%Y-%m')
     esaf_number    = str(proposal.get('experimentId') or '')
+    esaf_doi       = dm.get_esaf_doi(esaf_number)
 
-    _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date, esaf_number)
+    _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date, esaf_number, esaf_doi or '')
 
 
 def tag_manual(args):
@@ -824,7 +828,8 @@ def tag_manual(args):
         log.warning('Using PI info parsed from DM experiment name (first name, institution, email, badge will be empty)')
         pi = {'firstName': '', 'lastName': pi_last, 'institution': '', 'email': '', 'badge': ''}
 
-    _update_tag_pvs(args, pi, gup_str, proposal_title, exp_date, esaf_number)
+    esaf_doi = dm.get_esaf_doi(esaf_number)
+    _update_tag_pvs(args, pi, gup_str, proposal_title, exp_date, esaf_number, esaf_doi or '')
 
 
 def main():

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -47,6 +47,19 @@ def get_esaf_users(esaf_id):
         return set()
 
 
+def get_esaf_doi(esaf_id):
+    """Return the DOI string for the ESAF, or None if unavailable."""
+    if not esaf_id or not _DM_AVAILABLE:
+        return None
+    try:
+        station = os.environ.get('DM_STATION_NAME', '2BM')
+        esaf = esaf_api.getStationEsafById(station, int(esaf_id))
+        return esaf.get('doi') or None
+    except Exception as e:
+        log.warning('Could not retrieve DOI for ESAF %s: %s' % (esaf_id, str(e)))
+        return None
+
+
 def make_experiment_name(args):
     """Build the DM experiment name from proposal metadata.
 


### PR DESCRIPTION
`dmagic create` now builds the union of two user lists before creating the DM
experiment:

- **GUP users** (green): proposal experimenters + beamline contacts, retrieved from
  the APS scheduling REST API.
- **ESAF users** (cyan): users listed in the ESAF retrieved via
  `EsafApsDbApi.getStationEsafById(stationName, esafId)`, minus those already in the
  GUP list.

This ensures all users authorized for a beamtime — whether on the proposal or only
on the safety form — can download their data from DM.

`dmagic show` also displays the ESAF-only user badge list for verification before
running `create`.

---

## Bug fixes

- Fixed email send crash when a recipient address is rejected by the SMTP server.
- Fixed ambiguous prompt letter in the new-users-only email flow.
- Fixed new-user email tracking to show name alongside username in the new-user list.
- Removed unused `globus-server-top-dir` config parameter.

---

## Dependencies

- `dm` SDK (DM system, available on beamline machines): `ExperimentDsApi`,
  `UserDsApi`, `ExperimentDaqApi`, `EsafApsDbApi`. All DM imports are wrapped in a
  `try/except ImportError` so `dmagic show` and `dmagic tag` remain functional on
  machines without the DM SDK installed.
- `pyyaml` added to dependencies.

---

## Notes for reviewers

- The `ESAFDOINumber` EPICS PV must be defined as
  `record(waveform, ...) { field(FTVL, "CHAR") field(NELM, "256") }` in the
  tomoscan IOC database — `lso` record type is not handled correctly by pyepics for
  long strings.
- Experiment name format: `{YYYY-MM}-{PI_last_name}-{GUP_number}`.