### PR TITLE
Add list-esafs subcommand and assorted DM/email/CLI improvements

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -36,8 +36,20 @@ Key Commands
                          selection, then creates the experiment and adds all proposal users.
 
 - dmagic create-manual : Creates a DM experiment manually for commissioning runs or
-                         staff experiments that have no scheduling proposal. Badge numbers,
-                         PI name, and title are provided on the command line.
+                         staff experiments that have no scheduling proposal. PI name,
+                         title, and optional badge numbers are provided on the command
+                         line. Optional arguments:
+                           --gup   GUP number (default: 0 = no proposal/commissioning)
+                           --date  year-month in yyyy-mm format (default: current month)
+                           --start experiment start date in yyyy-mm-dd format
+                                   (default: first day of --date month)
+                           --end   experiment end date in yyyy-mm-dd format
+                                   (default: 14 days after --start)
+                         Experiment name format: yyyy-mm-{LastName}-{gup}
+                         Example: dmagic create-manual --name DeCarlo
+                                    --first-name Francesco --gup 1
+                                    --start 2026-05-01 --end 2026-05-07
+                                    --title "2-BM commissioning"
 
 - dmagic delete        : Deletes a DM experiment from Sojourner. Lists all experiments
                          for the station (last 2 years, including manually created ones)

--- a/README.txt
+++ b/README.txt
@@ -72,6 +72,16 @@ Key Commands
 - dmagic remove-user   : Removes one or more users from an existing DM experiment by
                          badge number. Shows the current user list before prompting.
 
+- dmagic list-users    : Lists all users currently granted access to a DM experiment,
+                         including their DM username, full name, and email address.
+
+- dmagic list-esafs    : Lists ESAFs for the beamline station in a date range using the
+                         DM EsafApsDbApi. Options:
+                           --start-date  range start in yyyy-mm-dd format
+                                         (default: first day of current month)
+                           --end-date    range end in yyyy-mm-dd format (default: today)
+                         Output: one line per ESAF with id, status, start/end dates, title.
+
 How It Works
 ------------
 

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -931,6 +931,8 @@ def main():
             write_sections = ('local', 'settings', 'site')
         else:
             write_sections = ('settings', 'site')
+        if hasattr(args, 'badges'):
+            args.badges = ''
         config.write(args.config, args=args, sections=write_sections)
     except RuntimeError as e:
         log.error(str(e))

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -124,10 +124,8 @@ def show(args):
     output = scheduling.beamtime_requests(run, auth, args)
     try:
         proposals = output[0]['activities']
-        # pprint.pprint(proposals, compact=True)
-    except IndexError:
-    # if not proposals:
-        log.error('No valid current experimentxxx')
+    except (IndexError, TypeError):
+        log.error('No proposals found for run %s — the run may not exist yet or no beamtime is scheduled' % run)
         return None
     try:
         log.error(proposals['message'])

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -298,17 +298,36 @@ def create_manual(args):
             return
     else:
         ref_date = now
-    args.year_month     = ref_date.strftime('%Y-%m')
+
+    if args.start:
+        try:
+            start_date = datetime.datetime.strptime(args.start, '%Y-%m-%d')
+        except ValueError:
+            log.error("Invalid --start '%s': expected format is yyyy-mm-dd (e.g. 2026-05-01)" % args.start)
+            return
+    else:
+        start_date = ref_date.replace(day=1)
+
+    if args.end:
+        try:
+            end_date = datetime.datetime.strptime(args.end, '%Y-%m-%d')
+        except ValueError:
+            log.error("Invalid --end '%s': expected format is yyyy-mm-dd (e.g. 2026-05-14)" % args.end)
+            return
+    else:
+        end_date = start_date + dt.timedelta(days=14)
+
+    args.year_month     = start_date.strftime('%Y-%m')
     args.pi_last_name   = args.name
     args.pi_first_name  = args.first_name
     args.pi_institution = args.institution
     args.pi_email       = args.email
     args.pi_badge       = ''
-    args.gup_number     = '0'
+    args.gup_number     = str(args.gup)
     args.gup_title      = args.title
     args.manual         = True
-    args.manual_start   = ref_date.strftime('%d-%b-%y')
-    args.manual_end     = (ref_date + dt.timedelta(days=14)).strftime('%d-%b-%y')
+    args.manual_start   = start_date.strftime('%d-%b-%y')
+    args.manual_end     = end_date.strftime('%d-%b-%y')
     log.info("Manual experiment: %s-%s, title: %s" % (
               args.year_month, args.pi_last_name, args.gup_title))
 

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -188,12 +188,38 @@ def show(args):
         if esaf_number and esaf_number != 'N/A':
             esaf_users = dm.get_esaf_users(esaf_number)
             if esaf_users:
-                log.esaf('\tESAF %s users (not in proposal):' % esaf_number)
+                log.esaf('\tESAF %s users:' % esaf_number)
                 for u in sorted(esaf_users):
                     log.esaf('\t\t %s' % u)
     else:
         time_now = datetime.datetime.now().astimezone() + dt.timedelta(args.set)
         log.warning('No proposal run on %s during %s' % (time_now, run))
+
+
+def list_esafs(args):
+    """List ESAFs for the beamline station in [--start-date, --end-date].
+
+    Defaults: start-date = first day of current month, end-date = today.
+    Station comes from DM_STATION_NAME env var, falling back to
+    args.experiment_type from the config file.
+    """
+    today = datetime.date.today()
+    start = args.start_date or today.replace(day=1).isoformat()
+    end   = args.end_date   or today.isoformat()
+    station = os.environ.get('DM_STATION_NAME') or args.experiment_type
+    log.info('Listing ESAFs for station %s from %s to %s' % (station, start, end))
+    rows = dm.list_esafs(start, end, station=station)
+    if not rows:
+        log.info('   No ESAFs found')
+        return
+    log.info('   Found %d ESAF(s)' % len(rows))
+    for e in rows:
+        log.info('   esafId=%s status=%s start=%s end=%s title=%s' % (
+            e.get('esafId', '?'),
+            e.get('esafStatus', '?'),
+            e.get('experimentStartDate', '?'),
+            e.get('experimentEndDate', '?'),
+            e.get('esafTitle', '')))
 
 
 def _finish_create(args, exp_name):
@@ -882,6 +908,7 @@ def main():
         ('add-user',      add_user,      config.CREATE_PARAMS, config.SITE_SUPPRESS, "Add users to an existing DM experiment by badge number"),
         ('remove-user',   remove_user,   config.CREATE_PARAMS, config.SITE_SUPPRESS, "Remove users from an existing DM experiment by badge number"),
         ('list-users',    list_users,    config.CREATE_PARAMS, config.SITE_SUPPRESS, "List all users with access to a DM experiment"),
+        ('list-esafs',    list_esafs,    config.LIST_ESAFS_PARAMS, config.SITE_SUPPRESS, "List ESAFs for the beamline station in a date range"),
     ]
 
     subparsers = parser.add_subparsers(title="Commands", metavar='')

--- a/dmagic/config.py
+++ b/dmagic/config.py
@@ -105,10 +105,18 @@ SECTIONS['manual'] = {
         'type': str,
         'default': '',
         'help': 'PI email address'},
+    'end': {
+        'type': str,
+        'default': '',
+        'help': 'Experiment end date in yyyy-mm-dd format (default: 14 days after --start or --date)'},
     'first-name': {
         'type': str,
         'default': '',
         'help': 'PI first name'},
+    'gup': {
+        'type': int,
+        'default': 0,
+        'help': 'GUP number (default: 0 = commissioning/no proposal)'},
     'institution': {
         'type': str,
         'default': '',
@@ -117,6 +125,10 @@ SECTIONS['manual'] = {
         'type': str,
         'default': 'Staff',
         'help': 'PI last name'},
+    'start': {
+        'type': str,
+        'default': '',
+        'help': 'Experiment start date in yyyy-mm-dd format (default: first day of --date month)'},
     'title': {
         'type': str,
         'default': 'Commissioning',

--- a/dmagic/config.py
+++ b/dmagic/config.py
@@ -146,15 +146,27 @@ SECTIONS['local'] = {
         'help': 'Top-level data directory on the analysis computer'},
     }
 
-INIT_PARAMS   = ('site',)
-SHOW_PARAMS   = ('settings', 'local')
-TAG_PARAMS    = ('settings',)
-CREATE_PARAMS = ('settings',)
-MANUAL_PARAMS = ('manual',)
-EMAIL_PARAMS  = ()
-DAQ_PARAMS    = ('local',)
-SITE_SUPPRESS = ('site',)
-NICE_NAMES    = ('General', 'Settings', 'Site', 'Manual', 'Local')
+SECTIONS['query'] = {
+    'start-date': {
+        'type': str,
+        'default': '',
+        'help': 'Range start date (YYYY-MM-DD); defaults to first day of current month'},
+    'end-date': {
+        'type': str,
+        'default': '',
+        'help': 'Range end date (YYYY-MM-DD); defaults to today'},
+    }
+
+INIT_PARAMS       = ('site',)
+SHOW_PARAMS       = ('settings', 'local')
+TAG_PARAMS        = ('settings',)
+CREATE_PARAMS     = ('settings',)
+MANUAL_PARAMS     = ('manual',)
+EMAIL_PARAMS      = ()
+DAQ_PARAMS        = ('local',)
+LIST_ESAFS_PARAMS = ('query',)
+SITE_SUPPRESS     = ('site',)
+NICE_NAMES        = ('General', 'Settings', 'Site', 'Manual', 'Local', 'Query')
 # Note: 'General' section only contains --config which is not logged
 
 

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -198,13 +198,13 @@ def add_users(exp_obj, username_list):
             log.error('   Could not find user {:s}: {:s}'.format(uname, str(e)))
             continue
         if uname in existing_unames:
-            log.warning('   User {:s} is already on the experiment'.format(
-                        make_pretty_user_name(user_obj)))
+            log.warning('   User {:s} ({:s}) is already on the experiment'.format(
+                        make_pretty_user_name(user_obj), uname))
             continue
         try:
             user_api.addUserExperimentRole(uname, 'User', exp_obj['name'])
-            log.info('   Added user {:s} to the DM experiment'.format(
-                        make_pretty_user_name(user_obj)))
+            log.info('   Added user {:s} ({:s}) to the DM experiment'.format(
+                        make_pretty_user_name(user_obj), uname))
         except Exception as e:
             log.error('   Could not add user {:s}: {:s}'.format(uname, str(e)))
 
@@ -219,8 +219,8 @@ def remove_users(exp_name, username_list):
             continue
         try:
             user_api.deleteUserExperimentRole(uname, 'User', exp_name)
-            log.info('   Removed user {:s} from the DM experiment'.format(
-                        make_pretty_user_name(user_obj)))
+            log.info('   Removed user {:s} ({:s}) from the DM experiment'.format(
+                        make_pretty_user_name(user_obj), uname))
         except Exception as e:
             log.error('   Could not remove user {:s}: {:s}'.format(uname, str(e)))
 

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -60,6 +60,26 @@ def get_esaf_doi(esaf_id):
         return None
 
 
+def list_esafs(start_date, end_date, station=None):
+    """Return ESAFs for the station in [start_date, end_date].
+
+    Wraps EsafApsDbApi.listStationEsafsByDateRange(). Dates are YYYY-MM-DD
+    strings. station defaults to DM_STATION_NAME env var (or '2BM').
+    Returns [] if DM is unavailable or the call fails.
+    """
+    if not _DM_AVAILABLE:
+        return []
+    if station is None:
+        station = os.environ.get('DM_STATION_NAME', '2BM')
+    try:
+        result = esaf_api.listStationEsafsByDateRange(
+            station, startDate=start_date, endDate=end_date)
+        return list(result) if result else []
+    except Exception as e:
+        log.error('Could not list ESAFs for station %s: %s' % (station, str(e)))
+        return []
+
+
 def make_experiment_name(args):
     """Build the DM experiment name from proposal metadata.
 

--- a/dmagic/message-2bm.txt
+++ b/dmagic/message-2bm.txt
@@ -54,8 +54,10 @@ Our storage capabilities are limited. It will be deleted permanently after that 
       <a href="https://tomopy.readthedocs.io/en/stable/">tomopy</a></li>
   <li>GPU based reconstruction software:
       <a href="https://tomocupy.readthedocs.io/en/latest/">tomocupy</a></li>
-  <li>Interesting dataset? Submit a pull request at
-      <a href="https://tomobank.readthedocs.io">tomobank.readthedocs.io</a></li>
+  <li>Interesting or challenging dataset? To make it available to the scientific community
+      and help improve our reconstruction software, you can share it at
+      <a href="https://tomobank.readthedocs.io">tomobank.readthedocs.io</a> &mdash;
+      just email <a href="mailto:tomobank@anl.gov">tomobank@anl.gov</a></li>
 </ul>
 
 <p>

--- a/dmagic/message-32id.txt
+++ b/dmagic/message-32id.txt
@@ -51,8 +51,8 @@ Our storage capabilities are limited. It will be deleted permanently after that 
 </ul>
 
 <p>
-Viktor Nikitin<br>
-<a href="mailto:vnikitin@anl.gov">vnikitin@anl.gov</a><br>
+The 32-ID TXM Team<br>
+Alberto Mittone (<a href="mailto:amittone@anl.gov">amittone@anl.gov</a>) and Viktor Nikitin (<a href="mailto:vnikitin@anl.gov">vnikitin@anl.gov</a>)<br>
 Advanced Photon Source
 </p>
 

--- a/dmagic/message-32id.txt
+++ b/dmagic/message-32id.txt
@@ -46,8 +46,10 @@ Our storage capabilities are limited. It will be deleted permanently after that 
       <a href="https://tomopy.readthedocs.io/en/stable/">tomopy</a></li>
   <li>GPU based reconstruction software:
       <a href="https://tomocupy.readthedocs.io/en/latest/">tomocupy</a></li>
-  <li>Interesting dataset? Submit a pull request at
-      <a href="https://tomobank.readthedocs.io">tomobank.readthedocs.io</a></li>
+  <li>Interesting or challenging dataset? To make it available to the scientific community
+      and help improve our reconstruction software, you can share it at
+      <a href="https://tomobank.readthedocs.io">tomobank.readthedocs.io</a> &mdash;
+      just email <a href="mailto:tomobank@anl.gov">tomobank@anl.gov</a></li>
 </ul>
 
 <p>

--- a/dmagic/message-7bm.txt
+++ b/dmagic/message-7bm.txt
@@ -19,8 +19,7 @@ argos (https://github.com/titusjan/argos)
 To run the reconstruction script you need to install tomopy:
 https://tomocupy.readthedocs.io/en/latest/
 
-If you have some interesting/challenging data set that you would like to share with the community submit a pull request at:
-https://tomobank.readthedocs.io
+Interesting or challenging dataset? To make it available to the scientific community and help improve our reconstruction software, you can share it at tomobank.readthedocs.io — just email tomobank@anl.gov
 
 Remember to send references to any papers written using data from APS to Alan at akastengren@anl.gov and Xiaoyang and lxiaoyang@anl.gov for inclusion in the APS Publications database.  Information on the database and the required acknowledgement statement for the use of APS can be found at https://www.aps.anl.gov/Science/Publications .
 =======

--- a/dmagic/message.py
+++ b/dmagic/message.py
@@ -151,6 +151,20 @@ def send_email(args):
     if choice == 't':
         emails = [args.secondary_beamline_contact_email]
         log.info('   *** TEST mode: sending only to secondary beamline contact')
+        s = smtplib.SMTP('mailhost.anl.gov')
+        for em in emails:
+            if args.msg['To'] is None:
+                args.msg['To'] = em
+            else:
+                args.msg.replace_header('To', em)
+            log.info('   Sending informational message to {:s}'.format(em))
+            try:
+                s.send_message(args.msg)
+            except smtplib.SMTPRecipientsRefused as e:
+                for addr, (code, msg) in e.recipients.items():
+                    log.warning('   Skipping {:s}: {:d} {:s}'.format(addr, code, msg.decode()))
+        s.quit()
+        return False  # test send does not update emailed-users record
     else:
         # Use pre-filtered user list if set by the caller (e.g. new-users-only mode)
         user_filter = getattr(args, '_user_filter', None)

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -223,17 +223,29 @@ dmagic create-manual
 --------------------
 
 Creates a DM experiment manually for commissioning runs or staff experiments that have
-no scheduling proposal. Badge numbers, PI name, and title are provided on the command
-line::
+no scheduling proposal. PI name, title, and optional badge numbers are provided on the
+command line. The experiment name is formatted as ``yyyy-mm-{LastName}-{gup}``.
 
-    (dm) $ dmagic create-manual --name DeCarlo --title "Vibration Tests" --badges 49734,218262
+Basic commissioning example (GUP 0, current month, 14-day window)::
+
+    (dm) $ dmagic create-manual --name DeCarlo --first-name Francesco --title "2-BM commissioning"
+
+With explicit GUP number and date range::
+
+    (dm) $ dmagic create-manual --name DeCarlo --first-name Francesco \
+              --title "2-BM run" --gup 1 --start 2026-05-01 --end 2026-05-07
+
+If an invalid date format is entered, the command exits with an error::
+
+    ERROR - Invalid --start '05/01/2026': expected format is yyyy-mm-dd (e.g. 2026-05-01)
 
 ::
 
     (dm) $ dmagic create-manual -h
     usage: dmagic create-manual [-h] [--badges BADGES] [--date DATE] [--email EMAIL]
-                                [--first-name FIRST_NAME] [--institution INSTITUTION]
-                                [--name NAME] [--title TITLE] [--config FILE]
+                                [--end END] [--first-name FIRST_NAME] [--gup GUP]
+                                [--institution INSTITUTION] [--name NAME]
+                                [--start START] [--title TITLE] [--config FILE]
 
     Create a DM experiment manually for commissioning runs
 
@@ -242,11 +254,16 @@ line::
       --badges BADGES       Comma-separated badge numbers to add to the experiment (default: )
       --date DATE           Year-month in yyyy-mm format (default: current month) (default: )
       --email EMAIL         PI email address (default: )
+      --end END             Experiment end date in yyyy-mm-dd format
+                            (default: 14 days after --start or --date) (default: )
       --first-name FIRST_NAME
                             PI first name (default: )
+      --gup GUP             GUP number (default: 0 = commissioning/no proposal) (default: 0)
       --institution INSTITUTION
                             PI institution (default: )
       --name NAME           PI last name (default: Staff)
+      --start START         Experiment start date in yyyy-mm-dd format
+                            (default: first day of --date month) (default: )
       --title TITLE         Experiment title (default: Commissioning)
       --config FILE         File name of configuration (default: /home/beams/2BMB/dmagic.conf)
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -170,10 +170,11 @@ DM Experiment Management
 =========================
 
 The ``create``, ``create-manual``, ``delete``, ``email``, ``daq-start``, ``daq-stop``,
-``add-user``, ``remove-user``, and ``list-users`` commands integrate with the APS Data Management (DM) system (Sojourner)
-to manage experiment records, user data access via Globus, and automated file transfer. These
-commands require the ``[site]`` section of ``~/dmagic.conf`` to be correctly configured
-(see `Initialization`_ above). The ``daq-start`` and ``daq-stop`` commands additionally
+``add-user``, ``remove-user``, ``list-users``, and ``list-esafs`` commands integrate
+with the APS Data Management (DM) system (Sojourner) to manage experiment records,
+user data access via Globus, automated file transfer, and ESAF queries. These commands
+require the ``[site]`` section of ``~/dmagic.conf`` to be correctly configured (see
+`Initialization`_ above). The ``daq-start`` and ``daq-stop`` commands additionally
 require the ``[local]`` section to be configured with the correct analysis hostname and
 data directory.
 
@@ -617,6 +618,44 @@ name, and email address::
       --set SET      Number of +/- days offset from today for past/future user groups (default: 0)
       --config FILE  File name of configuration (default: /home/beams/2BMB/dmagic.conf)
 
+dmagic list-esafs
+-----------------
+
+Lists ESAFs for the beamline station that fall in a given date range. Wraps
+``EsafApsDbApi.listStationEsafsByDateRange``. The station is taken from the
+``DM_STATION_NAME`` environment variable, falling back to the ``experiment-type``
+value in ``~/dmagic.conf``. If no dates are provided, the range defaults to
+**first day of the current month → today**::
+
+    (dm) $ dmagic list-esafs --start-date 2025-01-01 --end-date 2025-12-31 | head
+    2026-06-05 13:51:08,092 - Listing ESAFs for station 2BM from 2025-01-01 to 2025-12-31
+    2026-06-05 13:51:08,548 -    Found 8 ESAF(s)
+    2026-06-05 13:51:08,548 -    esafId=276896 status=Approved start=2025-03-25 08:00:00 end=2025-05-01 00:00:00 title=2-BM Operations Commissioning
+    2026-06-05 13:51:08,548 -    esafId=278851 status=Approved start=2025-04-10 00:00:00 end=2025-05-01 00:00:00 title=2-BM Technical Commissioning
+    2026-06-05 13:51:08,549 -    esafId=279513 status=Pending  start=2025-06-03 08:00:00 end=2025-08-06 00:00:00 title=2-BM Technical Commissioning
+    ...
+
+.. note::
+    This command requires a DM Python SDK that exposes
+    ``EsafApsDbApi.listStationEsafsByDateRange`` — available in the current production
+    install at ``/home/dm_bm/production/lib/python``. On older DM SDKs the command logs
+    an error and returns no ESAFs. Confirm the method is available with::
+
+        $ python -c "from dm import EsafApsDbApi; print('listStationEsafsByDateRange' in dir(EsafApsDbApi))"
+
+::
+
+    (dm) $ dmagic list-esafs -h
+    usage: dmagic list-esafs [-h] [--start-date START_DATE] [--end-date END_DATE] [--config FILE]
+
+    List ESAFs for the beamline station in a date range
+
+    options:
+      -h, --help               show this help message and exit
+      --start-date START_DATE  Range start date (YYYY-MM-DD); defaults to first day of current month (default: )
+      --end-date END_DATE      Range end date (YYYY-MM-DD); defaults to today (default: )
+      --config FILE            File name of configuration (default: /home/beams/2BMB/dmagic.conf)
+
 Command Reference
 =================
 
@@ -645,5 +684,5 @@ Command Reference
         upload       One-shot sync of all existing files to Sojourner (use when daq-start was not running)
         add-user     Add users to an existing DM experiment by badge number
         remove-user  Remove users from an existing DM experiment by badge number
-        upload       One-shot sync of all existing files to Sojourner (use when daq-start was not running)
         list-users   List all users with access to a DM experiment
+        list-esafs   List ESAFs for the beamline station in a date range


### PR DESCRIPTION
## Summary

New feature
- Add `dmagic list-esafs --start-date --end-date` subcommand wrapping
  `EsafApsDbApi.listStationEsafsByDateRange` to list ESAFs for the beamline
  station in a date range. Station resolves from `DM_STATION_NAME` env var,
  falling back to `experiment-type` in `~/dmagic.conf`. Dates default to
  first-of-current-month → today.

CLI / behavior fixes
- `dmagic show`: relabel "ESAF X users (not in proposal):" → "ESAF X users:".
  The previous label was misleading because the show path prints all ESAF
  experimenters without subtracting GUP users.
- `dmagic show`: handle missing run when `--set` points far into the future
  or past instead of crashing.
- `dmagic email`: track per-experiment emailed users in DM metadata so
  re-runs offer "[O]nly new users" vs "[A]ll users". Fix test mode (`T`)
  previously marking users as emailed. Update 32-ID signature and tomobank
  call-to-action.
- `dmagic create-manual`: add `--gup`, `--start`, `--end` options with
  yyyy-mm-dd validation.
- `dmagic add-user` / `remove-user`: show badge number alongside name in
  log messages; never persist `--badges` to `dmagic.conf` (clear before
  config write).

Docs
- Document `dmagic list-esafs` in `usage.rst` and `README.txt` (example
  output, `-h` dump, SDK-version note).
- Add the missing `dmagic list-users` entry to `README.txt`.
- Drop the duplicate `upload` line in the Command Reference.

## Test plan

- [ ] `dmagic list-esafs --start-date 2025-01-01 --end-date 2025-12-31` on a
      DM client with the upgraded SDK lists ESAFs for the year.
- [ ] `dmagic show` no longer shows the misleading "(not in proposal)" label.
- [ ] `dmagic email` in test mode (`T`) does NOT mark users as emailed; a
      subsequent `dmagic email` still treats them as new.
- [ ] `dmagic create-manual --gup N --start YYYY-MM-DD --end YYYY-MM-DD`
      validates dates and uses the provided values; invalid format errors out
      with a clear message.
- [ ] `dmagic show --set 5000` exits cleanly with a "no proposal found" log
      line.
- [ ] `dmagic add-user --badges 12345` adds the user, logs both the badge
      and the name, and leaves `~/dmagic.conf` with no `badges =` line.