### PR TITLE
Fix dmagic create missing beamtimes that show/tag could find

### DIFF
--- a/dmagic/scheduling.py
+++ b/dmagic/scheduling.py
@@ -159,6 +159,10 @@ def list_beamtimes(auth, args):
     """
     List all beamtimes scheduled for the run containing today + args.set days.
 
+    Uses the same `schedule/findByRunNameAndScheduleName` endpoint as
+    beamtime_requests() / `dmagic show`, so the set of beamtimes returned
+    is consistent with what `dmagic show` and `dmagic tag` display.
+
     Parameters
     ----------
     auth : HTTPBasicAuth
@@ -176,7 +180,7 @@ def list_beamtimes(auth, args):
         log.error("Could not determine run for the given --set offset")
         return []
 
-    end_point = "beamline-scheduling/sched-api/activity/findByRunNameAndBeamlineId"
+    end_point = "beamline-scheduling/sched-api/schedule/findByRunNameAndScheduleName"
     api_url = args.url + '/' + end_point + '/' + run + '/' + args.beamline
     reply = requests.get(api_url, auth=auth)
 
@@ -184,8 +188,13 @@ def list_beamtimes(auth, args):
         log.error("No response from the restAPI. Error: %s" % reply.status_code)
         return []
 
+    try:
+        activities = reply.json()[0]['activities']
+    except (IndexError, KeyError, TypeError):
+        return []
+
     beamtimes = []
-    for item in reply.json():
+    for item in activities:
         proposal = item['beamtime']['proposal']
         pi_last_name   = 'Unknown'
         pi_first_name  = ''


### PR DESCRIPTION
Reported by a user: `dmagic create` did not list the current experiment, while `dmagic show` and `dmagic tag` found it correctly.

Root cause: the two code paths hit different scheduling REST endpoints and returned different sets of beamtimes.

  show / tag (scheduling.beamtime_requests):
      .../sched-api/schedule/findByRunNameAndScheduleName/{run}/{beamline}

  create     (scheduling.list_beamtimes):
      .../sched-api/activity/findByRunNameAndBeamlineId/{run}/{beamline}

The activity endpoint had previously been replaced by the schedule endpoint in beamtime_requests() (see the commented-out line in that function) precisely because in the APS scheduling system a beamtime can be on the schedule before the corresponding "activity" exists — the activity is only created when the beamtime is finalized/activated, sometimes only near the start of the run. So an experiment that was already scheduled but not yet activated was visible to show/tag but invisible to create.

Fix: point list_beamtimes() at the same schedule endpoint and walk reply.json()[0][activities] the same way show does. The activity items inside the schedule payload expose the same fields list_beamtimes already uses (beamtime.proposal, startTime, endTime, experimentId), so the rest of the function — and the dicts it returns to create() — are unchanged.

Verify on a beamline machine: when the schedule shows a beamtime that `dmagic show` picks up, `dmagic create` now lists that same beamtime in its selection menu.