### PR TITLE
 Fix dmagic create beamtime lookup, and make dmagic upload/daq-start robust (source pre-check + dm-direct-mount workaround)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -82,6 +82,40 @@ Key Commands
                            --end-date    range end in yyyy-mm-dd format (default: today)
                          Output: one line per ESAF with id, status, start/end dates, title.
 
+DM data-directory format
+------------------------
+
+The [local] config knob 'dm-direct-mount' controls how dmagic hands the
+source path to the DM DAQ:
+
+  - dm-direct-mount = False (default): dmagic passes
+    '@{analysis}:{analysis-top-dir}/{exp-name}' — DM rsyncs from the
+    analysis host over SSH.
+
+  - dm-direct-mount = True: dmagic passes the bare local path
+    '{analysis-top-dir}/{exp-name}'. Use this when the DM VM already
+    mounts the analysis filesystem directly (e.g. the 2-BM DM VM has
+    tomodata2:/data2 mounted). Some DM installations have a bug in the
+    '@host:' syntax where the directory scan returns countFiles=0 with
+    "no new files for upload" for a directory that clearly contains
+    files; the bare-path form works correctly there.
+
+Passwordless SSH prerequisite
+-----------------------------
+
+'dmagic upload' and 'dmagic daq-start' pre-check the source directory before
+dispatching to DM. On beamline nodes that already mount the analysis top-dir
+(tomo1, tomo3, tocai, ...) no setup is needed. On a control computer that does
+NOT mount /data2 or /data3 (e.g. arcturus), dmagic falls back to an SSH probe
+on the analysis host — set up passwordless SSH once:
+
+    ssh-keygen -t ed25519 -N '' -f ~/.ssh/id_ed25519    # only if no key yet
+    ssh-copy-id tomodata2
+    ssh-copy-id tomodata3
+
+If SSH is not set up, dmagic prints a warning with the exact commands above
+and dispatches to DM anyway (the pre-check is a safety net, not required).
+
 How It Works
 ------------
 

--- a/dmagic/__main__.py
+++ b/dmagic/__main__.py
@@ -660,7 +660,8 @@ def start_daq(args):
     exp_name = _select_experiment(args, 'start DAQ for')
     if exp_name is None:
         return
-    dm.start_daq(exp_name, args.analysis, args.analysis_top_dir)
+    dm.start_daq(exp_name, args.analysis, args.analysis_top_dir,
+                 dm_direct_mount=getattr(args, 'dm_direct_mount', False))
 
 
 def stop_daq(args):
@@ -685,7 +686,8 @@ def upload(args):
     exp_name = _select_experiment(args, 'upload data for')
     if exp_name is None:
         return
-    dm.upload(exp_name, args.analysis, args.analysis_top_dir)
+    dm.upload(exp_name, args.analysis, args.analysis_top_dir,
+              dm_direct_mount=getattr(args, 'dm_direct_mount', False))
 
 
 def _update_tag_pvs(args, pi, proposal_num, proposal_title, exp_date, esaf_number='', esaf_doi=''):

--- a/dmagic/config.py
+++ b/dmagic/config.py
@@ -144,6 +144,14 @@ SECTIONS['local'] = {
         'type': str,
         'default': '/data3/2BM/',
         'help': 'Top-level data directory on the analysis computer'},
+    'dm-direct-mount': {
+        'default': False,
+        'action': 'store_true',
+        'help': 'True if the DM VM has the analysis-top-dir mounted '
+                'directly; when set, dmagic passes the bare local path '
+                '(e.g. /data2/2BM/exp) to daq_api.upload() / startDaq() '
+                'instead of prepending @{analysis}:. Works around a bug '
+                'in the @host: syntax on some DM installations.'},
     }
 
 SECTIONS['query'] = {

--- a/dmagic/dm.py
+++ b/dmagic/dm.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import subprocess
 
 from dmagic import log
 from dmagic import authorize
@@ -378,6 +379,166 @@ def make_data_link(args):
     return link
 
 
+def _inspect_local_source(local_path):
+    """Look at a local source directory that DM would read from.
+
+    Returns (status, count, size_bytes) where status is one of:
+      OK       - directory exists and has files
+      EMPTY    - directory exists but has no files
+      MISSING  - parent mount is visible but the directory is not there
+                 (usually a misconfigured analysis-top-dir or exp-name)
+      UNKNOWN  - parent mount is not visible from this host; caller
+                 should try _inspect_remote_source before giving up.
+    count and size_bytes are None for MISSING/UNKNOWN.
+    """
+    if os.path.isdir(local_path):
+        try:
+            entries = os.listdir(local_path)
+        except OSError:
+            return 'UNKNOWN', None, None
+        if not entries:
+            return 'EMPTY', 0, 0
+        total = 0
+        for name in entries:
+            try:
+                total += os.path.getsize(os.path.join(local_path, name))
+            except OSError:
+                pass
+        return 'OK', len(entries), total
+    parent = os.path.dirname(local_path.rstrip('/'))
+    if parent and os.path.isdir(parent):
+        return 'MISSING', None, None
+    return 'UNKNOWN', None, None
+
+
+_ssh_warned = set()  # hosts we've already emitted the setup warning for
+
+
+def _warn_ssh_setup(host, reason):
+    """Emit an actionable warning explaining how to enable passwordless
+    SSH so future dmagic runs get the source pre-check. Once per host
+    per process — we don't want to spam the same 6 lines for raw+rec.
+    """
+    if host in _ssh_warned:
+        return
+    _ssh_warned.add(host)
+    log.warning('Cannot SSH-check source on %s (%s).' % (host, reason))
+    log.warning('To enable dmagic to pre-check the source directory,')
+    log.warning('set up passwordless SSH from this host to %s once:' % host)
+    log.warning("    ssh-keygen -t ed25519 -N '' -f ~/.ssh/id_ed25519   # if you have no key yet")
+    log.warning('    ssh-copy-id %s' % host)
+    log.warning('    ssh -o BatchMode=yes %s "echo ok"                 # verify' % host)
+    log.warning('Continuing without pre-check; verify destination after transfer.')
+
+
+def _inspect_remote_source(host, path, timeout=5):
+    """Same as _inspect_local_source, but over SSH to `host`.
+
+    Uses BatchMode so it never prompts; if SSH is unusable (no key, host
+    unreachable, timeout) we log an actionable warning (once per host)
+    and return UNKNOWN so DM dispatches as before.
+    """
+    # Once we're SSH-connected we can distinguish three failure modes:
+    #   MISSING     - experiment dir missing, but analysis-top-dir exists
+    #   NO_TOPDIR   - analysis-top-dir itself does not exist on the host
+    #                 (usually the wrong --analysis or --analysis-top-dir)
+    # Never emit UNKNOWN from a successful SSH: we know what's on the host.
+    script = (
+        'p=%(p)s; '
+        'if [ -d "$p" ]; then '
+        '  n=$(find "$p" -maxdepth 1 -type f 2>/dev/null | wc -l); '
+        '  b=$(du -sb "$p" 2>/dev/null | cut -f1); '
+        '  [ "$n" = "0" ] && echo EMPTY || echo "OK $n $b"; '
+        'elif [ -d "$(dirname "$p")" ]; then echo MISSING; '
+        'else echo "NO_TOPDIR $(dirname "$p")"; fi'
+    ) % {'p': _shquote(path)}
+    try:
+        r = subprocess.run(
+            ['ssh', '-o', 'BatchMode=yes',
+             '-o', 'ConnectTimeout=%d' % timeout,
+             '-o', 'StrictHostKeyChecking=accept-new',
+             host, script],
+            capture_output=True, text=True, timeout=timeout + 10)
+    except Exception as e:
+        _warn_ssh_setup(host, str(e))
+        return 'UNKNOWN', None, None
+    if r.returncode != 0:
+        err = (r.stderr or '').strip().splitlines()
+        _warn_ssh_setup(host, err[-1] if err else 'ssh exit %d' % r.returncode)
+        return 'UNKNOWN', None, None
+    out = (r.stdout or '').strip()
+    if not out:
+        _warn_ssh_setup(host, 'empty response from remote probe')
+        return 'UNKNOWN', None, None
+    if out in ('EMPTY', 'MISSING'):
+        return out, (0 if out == 'EMPTY' else None), (0 if out == 'EMPTY' else None)
+    parts = out.split()
+    if len(parts) == 3 and parts[0] == 'OK':
+        try:
+            return 'OK', int(parts[1]), int(parts[2])
+        except ValueError:
+            return 'UNKNOWN', None, None
+    if len(parts) >= 2 and parts[0] == 'NO_TOPDIR':
+        # size_bytes carries the missing parent path so _report_source can name it
+        return 'NO_TOPDIR', None, ' '.join(parts[1:])
+    return 'UNKNOWN', None, None
+
+
+def _shquote(s):
+    """Minimal single-quote shell escaping for a path argument."""
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+def _inspect_source(host, path):
+    """Inspect a source dir on `host` at `path`.
+
+    Try locally first (works when the analysis mount is visible from the
+    machine running dmagic — beamline-node case). Fall back to SSH into
+    `host` when local returns UNKNOWN (control-computer case, e.g.
+    arcturus, which does not mount /data2 or /data3).
+    """
+    status, n, sz = _inspect_local_source(path)
+    if status != 'UNKNOWN':
+        return status, n, sz
+    return _inspect_remote_source(host, path)
+
+
+def _report_source(local_path, status, count, size_bytes, role):
+    """Log what _inspect_local_source found. role is 'raw' or 'rec'.
+
+    Missing raw is an error (dmagic is misconfigured); missing rec is a
+    warning (recon may not have run yet). Returns True if the caller
+    should proceed with the DM dispatch, False if it should skip.
+    """
+    if status == 'OK':
+        log.info('   Source has %d file(s), %.2f GiB'
+                 % (count, size_bytes / (1024.0 ** 3)))
+        return True
+    if status == 'EMPTY':
+        log.warning('   Source %s is empty; DM will transfer 0 files' % local_path)
+        return True
+    if status == 'MISSING':
+        if role == 'raw':
+            log.error('   Source %s does not exist on this host.' % local_path)
+            log.error('   Check --analysis / --analysis-top-dir; DM would '
+                      'silently accept and transfer nothing. Skipping.')
+        else:
+            log.warning('   Source %s does not exist yet (recon may not have run).'
+                        ' Skipping.' % local_path)
+        return False
+    if status == 'NO_TOPDIR':
+        # size_bytes was repurposed to carry the missing parent path
+        missing_parent = size_bytes or 'analysis-top-dir'
+        log.error('   Analysis top directory %s does not exist on the remote host.'
+                  % missing_parent)
+        log.error('   The --analysis host or --analysis-top-dir in ~/dmagic.conf is'
+                  ' wrong. DM would silently accept and transfer nothing. Skipping.')
+        return False
+    log.info('   Source path not visible from this host (no local mount); '
+             'proceeding without pre-check')
+    return True
+
+
 def _start_one_daq(exp_name, dm_dir_name, task_info, current_daqs):
     """Start a single DAQ if not already running for (exp_name, dm_dir_name).
 
@@ -398,13 +559,27 @@ def _start_one_daq(exp_name, dm_dir_name, task_info, current_daqs):
         return False
 
 
-def start_daq(exp_name, analysis, analysis_top_dir):
+def _dm_data_dir(analysis, local_path, dm_direct_mount):
+    """Format the dataDirectory URL for daq_api calls.
+
+    When dm_direct_mount is True the DM VM already mounts the source
+    filesystem directly, so we pass the bare local path. Otherwise we
+    prepend @{analysis}: for the remote-rsync syntax.
+    """
+    if dm_direct_mount:
+        return local_path
+    return '@{:s}:{:s}'.format(analysis, local_path)
+
+
+def start_daq(exp_name, analysis, analysis_top_dir, dm_direct_mount=False):
     """Start two DM DAQs for exp_name:
       - raw data:          analysis_top_dir/<exp_name>      → DM data directory
       - reconstructed data: analysis_top_dir/<exp_name>_rec → DM analysis directory
 
     The rec DAQ is skipped with a warning if the directory does not yet exist.
-    Returns True if at least the raw DAQ started, False on error.
+    If dm_direct_mount is True, the source URL passed to DM is the bare local
+    path; otherwise it is prefixed with @{analysis}:. Returns True if at least
+    the raw DAQ started, False on error.
     """
     log.info('Checking for already running DAQs for experiment %s' % exp_name)
     try:
@@ -415,17 +590,27 @@ def start_daq(exp_name, analysis, analysis_top_dir):
 
     top = analysis_top_dir.rstrip('/')
 
+    raw_local = os.path.join(top, exp_name)
+    rec_local = os.path.join(top, exp_name + '_rec')
+
     # Raw data DAQ → DM data directory
-    raw_dir = '@{:s}:{:s}'.format(analysis, os.path.join(top, exp_name))
+    raw_dir = _dm_data_dir(analysis, raw_local, dm_direct_mount)
     log.info('Starting raw data DAQ for experiment %s' % exp_name)
+    log.info('   Source: %s' % raw_dir)
+    raw_status, raw_n, raw_sz = _inspect_source(analysis, raw_local)
+    if not _report_source(raw_local, raw_status, raw_n, raw_sz, role='raw'):
+        return False
     raw_ok = _start_one_daq(exp_name, raw_dir, {}, current_daqs)
 
     # Reconstructed data DAQ → DM analysis directory
-    rec_dir = '@{:s}:{:s}'.format(analysis, os.path.join(top, exp_name + '_rec'))
+    rec_dir = _dm_data_dir(analysis, rec_local, dm_direct_mount)
     log.info('Starting reconstructed data DAQ for experiment %s' % exp_name)
-    rec_ok = _start_one_daq(exp_name, rec_dir, {'useAnalysisDirectory': True}, current_daqs)
+    log.info('   Source: %s' % rec_dir)
+    rec_status, rec_n, rec_sz = _inspect_source(analysis, rec_local)
+    rec_ok = False
+    if _report_source(rec_local, rec_status, rec_n, rec_sz, role='rec'):
+        rec_ok = _start_one_daq(exp_name, rec_dir, {'useAnalysisDirectory': True}, current_daqs)
     if not rec_ok:
-        log.warning('   Rec DAQ could not be started (directory may not exist yet)')
         log.warning('   Run "dmagic daq-start" again once reconstruction begins')
 
     return raw_ok
@@ -460,7 +645,7 @@ def stop_daq(exp_name):
     return True
 
 
-def upload(exp_name, analysis, analysis_top_dir):
+def upload(exp_name, analysis, analysis_top_dir, dm_direct_mount=False):
     """One-shot upload of raw and reconstructed data to the DM experiment.
 
     Uploads files that exist at the time the command is issued (unlike DAQ,
@@ -472,32 +657,39 @@ def upload(exp_name, analysis, analysis_top_dir):
       - reconstructed data: analysis_top_dir/<exp_name>_rec  → DM analysis directory
 
     The rec upload is skipped with a warning if the directory does not exist.
-    Returns True if at least the raw upload started, False on error.
+    If dm_direct_mount is True, the source URL passed to DM is the bare local
+    path; otherwise it is prefixed with @{analysis}:. Returns True if at
+    least the raw upload started, False on error.
     """
     top = analysis_top_dir.rstrip('/')
 
-    raw_dir = '@{:s}:{:s}'.format(analysis, os.path.join(top, exp_name))
-    rec_dir = '@{:s}:{:s}'.format(analysis, os.path.join(top, exp_name + '_rec'))
+    raw_local = os.path.join(top, exp_name)
+    rec_local = os.path.join(top, exp_name + '_rec')
+    raw_dir = _dm_data_dir(analysis, raw_local, dm_direct_mount)
+    rec_dir = _dm_data_dir(analysis, rec_local, dm_direct_mount)
 
     # Raw data → DM data directory
     log.info('Uploading raw data for experiment %s' % exp_name)
     log.info('   Source: %s' % raw_dir)
     raw_ok = False
-    try:
-        daq_api.upload(exp_name, raw_dir)
-        log.info('   Raw data upload started successfully')
-        raw_ok = True
-    except Exception as e:
-        log.error('   Could not start raw data upload: %s' % str(e))
+    raw_status, raw_n, raw_sz = _inspect_source(analysis, raw_local)
+    if _report_source(raw_local, raw_status, raw_n, raw_sz, role='raw'):
+        try:
+            daq_api.upload(exp_name, raw_dir)
+            log.info('   Raw data upload dispatched to DM')
+            raw_ok = True
+        except Exception as e:
+            log.error('   Could not start raw data upload: %s' % str(e))
 
     # Reconstructed data → DM analysis directory
     log.info('Uploading reconstructed data for experiment %s' % exp_name)
     log.info('   Source: %s' % rec_dir)
-    try:
-        daq_api.upload(exp_name, rec_dir, {'useAnalysisDirectory': True})
-        log.info('   Reconstructed data upload started successfully')
-    except Exception as e:
-        log.warning('   Could not start reconstructed data upload: %s' % str(e))
-        log.warning('   (directory may not exist yet)')
+    rec_status, rec_n, rec_sz = _inspect_source(analysis, rec_local)
+    if _report_source(rec_local, rec_status, rec_n, rec_sz, role='rec'):
+        try:
+            daq_api.upload(exp_name, rec_dir, {'useAnalysisDirectory': True})
+            log.info('   Reconstructed data upload dispatched to DM')
+        except Exception as e:
+            log.warning('   Could not start reconstructed data upload: %s' % str(e))
 
     return raw_ok

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -178,6 +178,54 @@ require the ``[site]`` section of ``~/dmagic.conf`` to be correctly configured (
 require the ``[local]`` section to be configured with the correct analysis hostname and
 data directory.
 
+DM data-directory format: ``dm-direct-mount``
+---------------------------------------------
+
+The ``[local]`` config knob ``dm-direct-mount`` controls how dmagic hands the
+source path to the DM DAQ:
+
+- ``dm-direct-mount = False`` (default) — dmagic passes
+  ``@{analysis}:{analysis-top-dir}/{exp-name}`` to ``daq_api.upload()`` /
+  ``startDaq()``. DM then rsyncs from the analysis host over SSH.
+- ``dm-direct-mount = True`` — dmagic passes the bare local path
+  ``{analysis-top-dir}/{exp-name}``. Use this when the DM VM already mounts
+  the analysis filesystem directly (for example, the 2-BM DM VM has
+  ``tomodata2:/data2`` mounted). On some DM installations the ``@host:``
+  syntax has a bug where ``daq_api.upload()`` returns ``countFiles=0`` with
+  ``"no new files for upload"`` even for a directory that contains matching
+  files; the bare-path form works correctly there.
+
+Passwordless SSH prerequisite (for source pre-check)
+----------------------------------------------------
+
+``dmagic upload`` and ``dmagic daq-start`` inspect the source directory
+(``{analysis-top-dir}/{exp-name}`` and its ``_rec`` sibling) **before** dispatching to
+DM, and warn if it is empty or missing. This is important because the DM DAQ silently
+accepts a nonexistent source and reports "started successfully" while transferring zero
+bytes — a misconfigured ``analysis`` / ``analysis-top-dir`` in ``~/dmagic.conf`` can
+otherwise produce a successful-looking run with an empty destination.
+
+The pre-check works two ways:
+
+- If the host running dmagic already mounts the analysis directory (typical on beamline
+  nodes like ``tomo1``, ``tomo3``, ``tocai``), the check is done locally with no setup.
+
+- If dmagic is run from a control computer that does **not** mount ``/data2`` /
+  ``/data3`` (typical on ``arcturus``), dmagic falls back to an SSH probe on the
+  analysis host. This requires passwordless SSH to be set up **once**::
+
+      # On the control computer, as 2bmb
+      ssh-keygen -t ed25519 -N '' -f ~/.ssh/id_ed25519    # only if you don't have a key yet
+      ssh-copy-id tomodata2
+      ssh-copy-id tomodata3
+      # verify
+      ssh -o BatchMode=yes tomodata2 'echo ok'
+      ssh -o BatchMode=yes tomodata3 'echo ok'
+
+If SSH cannot be used (no key, host unreachable), dmagic logs a warning with the
+setup steps above and dispatches to DM anyway — the pre-check is a safety net, not a
+hard requirement.
+
 dmagic create
 -------------
 


### PR DESCRIPTION
## Summary

Two fixes uncovered while running the first real end-to-end
dmagic-driven DM upload at 2-BM.

**1. `dmagic create` — use the same scheduling endpoint as show/tag**

A beamline user reported that a currently active experiment showed up
in `dmagic show` and `dmagic tag` but was missing from the list in
`dmagic create`. The two code paths hit different scheduling REST
endpoints:

  show / tag → beamline-scheduling/sched-api/schedule/findByRunNameAndScheduleName
  create     → beamline-scheduling/sched-api/activity/findByRunNameAndBeamlineId

The activity endpoint had been intentionally replaced by the schedule
endpoint in `beamtime_requests()` (see the commented-out line in that
function) because in the APS scheduling system a beamtime can be on
the schedule before the corresponding "activity" is created — so an
experiment scheduled but not yet activated was invisible to `create`
while `show` and `tag` picked it up.

Point `list_beamtimes()` at the same schedule endpoint and iterate
`reply.json()[0]['activities']` the same way `show` does. The activity
items inside the schedule payload expose the same fields
list_beamtimes already consumed (`beamtime.proposal`, `startTime`,
`endTime`, `experimentId`), so downstream code is unchanged.

**2. `dmagic upload` / `daq-start` — pre-check source; add
    dm-direct-mount workaround**

Previously dmagic dispatched `daq_api.upload()` / `startDaq()` without
checking whether the source directory existed. DM's DAQ silently
accepts a nonexistent source and reports "started successfully" while
transferring zero bytes — a misconfigured `--analysis-top-dir` or
`--analysis` produces a successful-looking run with an empty
destination. Hit in the field when the config pointed at
`tomodata3:/data3/2BM/` but data actually lived on `tomodata2:/data2/`
(and `/data3/2BM/` doesn't even exist on `tomodata3`).

Added `_inspect_source(host, path)` that:
- tries locally first (works on beamline nodes that NFS-mount the
  analysis top-dir);
- falls back to an SSH probe on the analysis host using BatchMode,
  for control computers (e.g. `arcturus`) that don't mount `/data2`
  or `/data3` but can passwordlessly ssh to `tomodata2` /
  `tomodata3`;
- distinguishes OK / EMPTY / MISSING / NO_TOPDIR / UNKNOWN so
  `_report_source()` can either log the file count + GiB and proceed
  (OK), warn and proceed (EMPTY), warn and skip (rec MISSING — recon
  may not have run), or error and skip (raw MISSING; NO_TOPDIR
  when even the parent doesn't exist);
- degrades to UNKNOWN + dispatch-anyway if SSH is unusable, and
  emits a one-time actionable warning per host explaining how to set
  up passwordless SSH (ssh-keygen + ssh-copy-id commands).

Also added a `dm-direct-mount` boolean to the `[local]` section of
`dmagic.conf`. Some DM installations mis-handle the `@{analysis}:{path}`
dataDirectory form: at 2-BM,
`daq_api.upload('@tomodata2:/data2/2BM/2026-07-Suwandi-1012958')`
returns `status=done, countFiles=0,
errorMessage="no new files for upload"` — even though the directory
contains matching .h5 files. Passing the same URL with
`taskInfo={'experimentFilePath': <name>}` works, and passing the bare
local path `/data2/2BM/…` works too. The 2-BM DM VM has
`tomodata2:/data2` mounted directly, so the remote-rsync syntax isn't
needed. DM support (Sinisa) confirmed the `@host:` syntax has a bug
and will be fixed on their side; in the meantime this option
sidesteps it. When `dm-direct-mount = True`, dmagic passes the bare
local path; when False (default) it keeps the existing
`@{analysis}:{path}` form.

Docs updated in `README.txt` and `docs/source/usage.rst` with both
the SSH prerequisite and the `dm-direct-mount` option — when to set
it and the symptom that motivated it.

## Test plan

- [ ] `dmagic create` lists a beamtime that is on the current schedule
      but was previously only visible in `dmagic show` / `dmagic tag`.
- [ ] `dmagic upload` with a wrong `--analysis-top-dir` no longer
      dispatches silently; it prints
      `Analysis top directory X does not exist on the remote host`
      (from a control computer via SSH) or
      `Source X does not exist on this host` (from a beamline node
      with a direct mount) and skips.
- [ ] `dmagic upload` on a well-configured beamline node prints
      `Source has N file(s), X.XX GiB` before dispatching and DM's
      per-experiment record shows `countFiles=N`.
- [ ] With `dm-direct-mount = True` and matching `analysis-top-dir`
      set to a path the DM VM mounts directly, `dmagic upload`
      dispatches with a bare local path and DM's directory scan
      returns the true file count instead of zero.
- [ ] If SSH is not set up from the control computer, `dmagic upload`
      prints the one-time SSH-setup warning and still dispatches
      (no crash, no silent no-op suppression).